### PR TITLE
Add options to position robot when importing macro.

### DIFF
--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -27,9 +27,14 @@
    <!-- convert to property to use substitution in function -->
    <xacro:property name="initial_positions_file" default="$(arg initial_positions_file)"/>
 
+   <!-- create link fixed to the "world" -->
+   <link name="world" />
+
    <!-- arm -->
    <xacro:ur_robot
+     name="$(arg name)"
      prefix="$(arg prefix)"
+     parent="world"
      joint_limits_parameters_file="$(arg joint_limit_params)"
      kinematics_parameters_file="$(arg kinematics_params)"
      physical_parameters_file="$(arg physical_params)"
@@ -42,5 +47,8 @@
      fake_sensor_commands="$(arg fake_sensor_commands)"
      headless_mode="$(arg headless_mode)"
      initial_positions="${load_yaml(initial_positions_file)}"
-     use_tool_communication="$(arg use_tool_communication)" />
+     use_tool_communication="$(arg use_tool_communication)" >
+     <origin xyz="0 0 0" rpy="0 0 0" />          <!-- position robot in the world -->
+   </xacro:ur_robot>
+
 </robot>

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -54,7 +54,10 @@
   <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
 
   <xacro:macro name="ur_robot" params="
+    name
     prefix
+    parent
+    *origin
     joint_limits_parameters_file
     kinematics_parameters_file
     physical_parameters_file
@@ -87,7 +90,7 @@
     <xacro:include filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
     <!-- ros2 control instance -->
     <xacro:ur_ros2_control
-      name="URPositionHardwareInterface" prefix="${prefix}"
+      name="${name}" prefix="${prefix}"
       use_fake_hardware="$(arg use_fake_hardware)"
       initial_positions="${initial_positions}"
       fake_sensor_commands="$(arg fake_sensor_commands)"
@@ -246,6 +249,13 @@
         <origin xyz="0.0 0.0 ${-0.5 * wrist_3_inertia_length}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
+
+    <!-- base_joint fixes base_link to the environment -->
+    <joint name="${prefix}base_joint" type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}base_link" />
+    </joint>
 
     <!-- joints - main serial chain -->
     <joint name="${prefix}base_link-base_link_inertia" type="fixed">


### PR DESCRIPTION
This is a small improvement useful when integrating macro into a bigger XACRO file, e.g., of a robotic cell.﻿
