### PR TITLE
Set default resource file paths to empty strings

### DIFF
--- a/launch/view_ur.launch.py
+++ b/launch/view_ur.launch.py
@@ -116,15 +116,6 @@ def generate_launch_description():
     visual_params = PathJoinSubstitution(
         [FindPackageShare(description_package), "config", ur_type, "visual_parameters.yaml"]
     )
-    script_filename = PathJoinSubstitution(
-        [FindPackageShare("ur_robot_driver"), "resources", "ros_control.urscript"]
-    )
-    input_recipe_filename = PathJoinSubstitution(
-        [FindPackageShare("ur_robot_driver"), "resources", "rtde_input_recipe.txt"]
-    )
-    output_recipe_filename = PathJoinSubstitution(
-        [FindPackageShare("ur_robot_driver"), "resources", "rtde_output_recipe.txt"]
-    )
 
     robot_description_content = Command(
         [
@@ -155,15 +146,6 @@ def generate_launch_description():
             " ",
             "name:=",
             ur_type,
-            " ",
-            "script_filename:=",
-            script_filename,
-            " ",
-            "input_recipe_filename:=",
-            input_recipe_filename,
-            " ",
-            "output_recipe_filename:=",
-            output_recipe_filename,
             " ",
             "prefix:=",
             prefix,

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -80,9 +80,9 @@
       visual_parameters_file="${visual_parameters_file}"/>
 
     <!-- Data files required by the UR driver -->
-    <xacro:arg name="script_filename" default="$(find ur_robot_driver)/resources/ros_control.urscript"/>
-    <xacro:arg name="output_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"/>
-    <xacro:arg name="input_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"/>
+    <xacro:arg name="script_filename" default=""/>
+    <xacro:arg name="output_recipe_filename" default=""/>
+    <xacro:arg name="input_recipe_filename" default=""/>
     <xacro:arg name="robot_ip" default="10.0.1.186"/>
 
 


### PR DESCRIPTION
Using the default resource files from the ur_robot driver adds a dependency
to the driver that is not strictly necessary. Defaulting to empty values
will remove the explicit dependency.

Strictly, I consider this an unproper solution, as the ros2_control plugin is still there.

This is a minimal straight-forward solution to be able to use this repository and start the `view_ur.launch.py` file without installing the driver and all its dependencies.

This concerns #6 