### PR TITLE
Fix calibration checksum propagation.

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -31,7 +31,7 @@
           <param name="servoj_gain">2000</param>
           <param name="servoj_lookahead_time">0.03</param>
           <param name="use_tool_communication">${use_tool_communication}</param>
-          <param name="kinematics/hash">"${hash_kinematics}"</param>
+          <param name="kinematics/hash">${hash_kinematics}</param>
           <param name="tool_voltage">0</param>
           <param name="tool_parity">0</param>
           <param name="tool_baud_rate">115200</param>


### PR DESCRIPTION
Needed for fixing UniversalRobots/Universal_Robots_ROS2_Driver#258