### PR TITLE
Use 'gpio' insted of 'joint' ros2_control tag for configuration and state interfaces

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -274,6 +274,14 @@
           <state_interface name="safety_status_bit_10"/>
         </joint>
 
+        <gpio name="payload">
+          <command_interface name="mass"/>
+          <command_interface name="cog.x"/>
+          <command_interface name="cog.y"/>
+          <command_interface name="cog.z"/>
+          <command_interface name="payload_async_success"/>
+        </gpio>
+
         <joint name="resend_robot_program">
           <command_interface name="resend_robot_program_cmd"/>
           <command_interface name="resend_robot_program_async_success"/>

--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -162,14 +162,14 @@
         </sensor>
 
         <!-- NOTE The following are joints used only for testing with fake hardware and will change in the future -->
-        <joint name="speed_scaling">
+        <gpio name="speed_scaling">
           <state_interface name="speed_scaling_factor"/>
           <param name="initial_speed_scaling_factor">1</param>
           <command_interface name="target_speed_fraction_cmd"/>
           <command_interface name="target_speed_fraction_async_success"/>
-        </joint>
+        </gpio>
 
-        <joint name="gpio">
+        <gpio name="gpio">
           <command_interface name="standard_digital_output_cmd_0"/>
           <command_interface name="standard_digital_output_cmd_1"/>
           <command_interface name="standard_digital_output_cmd_2"/>
@@ -272,7 +272,7 @@
           <state_interface name="safety_status_bit_8"/>
           <state_interface name="safety_status_bit_9"/>
           <state_interface name="safety_status_bit_10"/>
-        </joint>
+        </gpio>
 
         <gpio name="payload">
           <command_interface name="mass"/>
@@ -282,14 +282,14 @@
           <command_interface name="payload_async_success"/>
         </gpio>
 
-        <joint name="resend_robot_program">
+        <gpio name="resend_robot_program">
           <command_interface name="resend_robot_program_cmd"/>
           <command_interface name="resend_robot_program_async_success"/>
-        </joint>
+        </gpio>
 
-        <joint name="system_interface">
+        <gpio name="system_interface">
           <state_interface name="initialized"/>
-        </joint>
+        </gpio>
 
       </xacro:unless>
 

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -35,7 +35,7 @@
    <xacro:arg name="sim_ignition" default="false" />
    <xacro:arg name="simulation_controllers" default="" />
 
-   <!-- initial position for fake hardware -->
+   <!-- initial position for simulations (Fake Hardware, Gazebo, Ignition) -->
    <xacro:arg name="initial_positions_file" default="$(find ur_description)/config/initial_positions.yaml"/>
 
    <!-- convert to property to use substitution in function -->


### PR DESCRIPTION
This functionality is recently released to rolling and fully supported by FakeHardware.
This is attempt to make code simpler (see  UniversalRobots/Universal_Robots_ROS2_Driver#224) and URDF clerer.

