### PR TITLE
Use more default parameters in xacro to reduce complexity of launch files.

### DIFF
--- a/launch/view_ur.launch.py
+++ b/launch/view_ur.launch.py
@@ -104,36 +104,11 @@ def generate_launch_description():
     description_file = LaunchConfiguration("description_file")
     prefix = LaunchConfiguration("prefix")
 
-    joint_limit_params = PathJoinSubstitution(
-        [FindPackageShare(description_package), "config", ur_type, "joint_limits.yaml"]
-    )
-    kinematics_params = PathJoinSubstitution(
-        [FindPackageShare(description_package), "config", ur_type, "default_kinematics.yaml"]
-    )
-    physical_params = PathJoinSubstitution(
-        [FindPackageShare(description_package), "config", ur_type, "physical_parameters.yaml"]
-    )
-    visual_params = PathJoinSubstitution(
-        [FindPackageShare(description_package), "config", ur_type, "visual_parameters.yaml"]
-    )
-
     robot_description_content = Command(
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
             " ",
             PathJoinSubstitution([FindPackageShare(description_package), "urdf", description_file]),
-            " ",
-            "joint_limit_params:=",
-            joint_limit_params,
-            " ",
-            "kinematics_params:=",
-            kinematics_params,
-            " ",
-            "physical_params:=",
-            physical_params,
-            " ",
-            "visual_params:=",
-            visual_params,
             " ",
             "safety_limits:=",
             safety_limits,
@@ -145,6 +120,9 @@ def generate_launch_description():
             safety_k_position,
             " ",
             "name:=",
+            "ur",
+            " ",
+            "ur_type:=",
             ur_type,
             " ",
             "prefix:=",

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -5,12 +5,15 @@
    <!-- import main macro -->
    <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
 
+   <!-- possible 'ur_type' values: ur3, ur3e, ur5, ur5e, ur10, ur10e, ur16e -->
+   <xacro:arg name="ur_type" default=""/>
+
    <!-- parameters -->
    <xacro:arg name="prefix" default="" />
-   <xacro:arg name="joint_limit_params" default=""/>
-   <xacro:arg name="kinematics_params" default=""/>
-   <xacro:arg name="physical_params" default=""/>
-   <xacro:arg name="visual_params" default=""/>
+   <xacro:arg name="joint_limit_params" default="$(find ur_description)/config/$(arg ur_type)/joint_limits.yaml"/>
+   <xacro:arg name="kinematics_params" default="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"/>
+   <xacro:arg name="physical_params" default="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"/>
+   <xacro:arg name="visual_params" default="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"/>
    <xacro:arg name="transmission_hw_interface" default=""/>
    <xacro:arg name="safety_limits" default="false"/>
    <xacro:arg name="safety_pos_margin" default="0.15"/>

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -6,7 +6,7 @@
    <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
 
    <!-- possible 'ur_type' values: ur3, ur3e, ur5, ur5e, ur10, ur10e, ur16e -->
-   <xacro:arg name="ur_type" default=""/>
+   <xacro:arg name="ur_type"/>
 
    <!-- parameters -->
    <xacro:arg name="prefix" default="" />


### PR DESCRIPTION
This PR proposes to use more  default parameters in the xacro file to simplify the launch files.
For that an additional agument is added, but four mandatory arguments are reduced.

The motivation is that in many use-cases people will use default parameters. Especially when starting using ROS driver.
The parameters can be still adjusted to custom need.﻿
