### PR TITLE
Multi robot

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -14,7 +14,9 @@
     input_recipe_filename tf_prefix
     hash_kinematics robot_ip
     tool_voltage:=24 tool_parity:=0 tool_baud_rate:=115200 tool_stop_bits:=1
-    tool_rx_idle_chars:=1.5 tool_tx_idle_chars:=3.5 tool_device_name:=/tmp/ttyUR tool_tcp_port:=54321">
+    tool_rx_idle_chars:=1.5 tool_tx_idle_chars:=3.5 tool_device_name:=/tmp/ttyUR tool_tcp_port:=54321
+    reverse_port:=50001
+    script_sender_port:=50002">
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -36,8 +38,8 @@
           <param name="output_recipe_filename">${output_recipe_filename}</param>
           <param name="input_recipe_filename">${input_recipe_filename}</param>
           <param name="headless_mode">${headless_mode}</param>
-          <param name="reverse_port">50001</param>
-          <param name="script_sender_port">50002</param>
+          <param name="reverse_port">${reverse_port}</param>
+          <param name="script_sender_port">${script_sender_port}</param>
           <param name="tf_prefix">"${tf_prefix}"</param>
           <param name="non_blocking_read">0</param>
           <param name="servoj_gain">2000</param>

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -18,6 +18,9 @@
    <!-- ros2_control related parameters -->
    <xacro:arg name="headless_mode" default="false" />
    <xacro:arg name="robot_ip" default="0.0.0.0" />
+   <xacro:arg name="script_filename" default=""/>
+   <xacro:arg name="output_recipe_filename" default=""/>
+   <xacro:arg name="input_recipe_filename" default=""/>
    <!--   tool communication related parameters-->
    <xacro:arg name="use_tool_communication" default="false" />
    <xacro:arg name="tool_voltage" default="24" />

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -17,6 +17,7 @@
    <xacro:arg name="safety_k_position" default="20"/>
    <!-- ros2_control related parameters -->
    <xacro:arg name="headless_mode" default="false" />
+   <xacro:arg name="robot_ip" default="0.0.0.0" />
    <!--   tool communication related parameters-->
    <xacro:arg name="use_tool_communication" default="false" />
    <xacro:arg name="tool_voltage" default="24" />
@@ -71,7 +72,8 @@
      tool_rx_idle_chars="$(arg tool_rx_idle_chars)"
      tool_tx_idle_chars="$(arg tool_tx_idle_chars)"
      tool_device_name="$(arg tool_device_name)"
-     tool_tcp_port="$(arg tool_tcp_port)" >
+     tool_tcp_port="$(arg tool_tcp_port)"
+     robot_ip="$(arg robot_ip)" >
      <origin xyz="0 0 0" rpy="0 0 0" />          <!-- position robot in the world -->
    </xacro:ur_robot>
 

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -80,7 +80,8 @@
     tool_rx_idle_chars:=1.5
     tool_tx_idle_chars:=3.5
     tool_device_name:=/tmp/ttyUR
-    tool_tcp_port:=54321" >
+    tool_tcp_port:=54321
+    robot_ip:=0.0.0.0" >
 
     <!-- Load configuration data from the provided .yaml files -->
     <xacro:read_model_data
@@ -94,7 +95,6 @@
     <xacro:arg name="script_filename" default=""/>
     <xacro:arg name="output_recipe_filename" default=""/>
     <xacro:arg name="input_recipe_filename" default=""/>
-    <xacro:arg name="robot_ip" default="10.0.1.186"/>
 
 
     <!-- ros2 control include -->
@@ -113,7 +113,7 @@
       input_recipe_filename="$(arg input_recipe_filename)"
       tf_prefix=""
       hash_kinematics="${kinematics_hash}"
-      robot_ip="$(arg robot_ip)"
+      robot_ip="${robot_ip}"
       use_tool_communication="${use_tool_communication}"
       tool_voltage="${tool_voltage}"
       tool_parity="${tool_parity}"

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -81,7 +81,10 @@
     tool_tx_idle_chars:=3.5
     tool_device_name:=/tmp/ttyUR
     tool_tcp_port:=54321
-    robot_ip:=0.0.0.0" >
+    robot_ip:=0.0.0.0
+    script_filename:=to_be_filled_by_ur_robot_driver
+    output_recipe_filename:=to_be_filled_by_ur_robot_driver
+    input_recipe_filename:=to_be_filled_by_ur_robot_driver" >
 
     <!-- Load configuration data from the provided .yaml files -->
     <xacro:read_model_data
@@ -90,11 +93,6 @@
       physical_parameters_file="${physical_parameters_file}"
       visual_parameters_file="${visual_parameters_file}"
       force_abs_paths="${sim_gazebo or sim_ignition}"/>
-
-    <!-- Data files required by the UR driver -->
-    <xacro:arg name="script_filename" default=""/>
-    <xacro:arg name="output_recipe_filename" default=""/>
-    <xacro:arg name="input_recipe_filename" default=""/>
 
 
     <!-- ros2 control include -->
@@ -108,9 +106,9 @@
       headless_mode="${headless_mode}"
       sim_gazebo="${sim_gazebo}"
       sim_ignition="${sim_ignition}"
-      script_filename="$(arg script_filename)"
-      output_recipe_filename="$(arg output_recipe_filename)"
-      input_recipe_filename="$(arg input_recipe_filename)"
+      script_filename="${script_filename}"
+      output_recipe_filename="${output_recipe_filename}"
+      input_recipe_filename="${input_recipe_filename}"
       tf_prefix=""
       hash_kinematics="${kinematics_hash}"
       robot_ip="${robot_ip}"

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -84,7 +84,9 @@
     robot_ip:=0.0.0.0
     script_filename:=to_be_filled_by_ur_robot_driver
     output_recipe_filename:=to_be_filled_by_ur_robot_driver
-    input_recipe_filename:=to_be_filled_by_ur_robot_driver" >
+    input_recipe_filename:=to_be_filled_by_ur_robot_driver
+    reverse_port:=50001
+    script_sender_port:=50002">
 
     <!-- Load configuration data from the provided .yaml files -->
     <xacro:read_model_data
@@ -120,7 +122,10 @@
       tool_rx_idle_chars="${tool_rx_idle_chars}"
       tool_tx_idle_chars="${tool_tx_idle_chars}"
       tool_device_name="${tool_device_name}"
-      tool_tcp_port="${tool_tcp_port}"/>
+      tool_tcp_port="${tool_tcp_port}"
+      reverse_port="${reverse_port}"
+      script_sender_port="${script_sender_port}"
+      />
 
     <!-- Add URDF transmission elements (for ros_control) -->
     <!--<xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />-->


### PR DESCRIPTION
This PR aims at adding the possibility to create multi-UR-environments with more than one robot in the scene.

As the argument can only be set once, it is not possible to instanciate multiple `ur_robot` macro instances with different `robot_ip` arguments.

To complete this, I removed all arguments from the macro and moved them towards parameters instead. This enables greater flexibility for using the macro.

@RobertWilbrandt as discussed, it would be nice if you could also give it a look.