### PR TITLE
xacro:arg does need a default tag

### DIFF
--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -6,7 +6,8 @@
    <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
 
    <!-- possible 'ur_type' values: ur3, ur3e, ur5, ur5e, ur10, ur10e, ur16e -->
-   <xacro:arg name="ur_type"/>
+   <!-- the default value should raise an error in case this was called without defining the type -->
+   <xacro:arg name="ur_type" default="ur5x"/>
 
    <!-- parameters -->
    <xacro:arg name="prefix" default="" />


### PR DESCRIPTION
As I falsely suggested previously, xacro:arg does not allow skipping the default value.