### PR TITLE
First hacky implementation of reusing the initial_positions for view_ur

### DIFF
--- a/launch/view_ur.launch.py
+++ b/launch/view_ur.launch.py
@@ -28,11 +28,16 @@
 #
 # Author: Denis Stogl
 
+import os
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from ament_index_python.packages import get_package_share_directory
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+
+import yaml
 
 
 def generate_launch_description():
@@ -131,6 +136,16 @@ def generate_launch_description():
     )
     robot_description = {"robot_description": robot_description_content}
 
+    initial_positions_file = os.path.join(
+        get_package_share_directory("ur_description"), "config", "initial_positions.yaml"
+    )
+    print(initial_positions_file)
+    with open(initial_positions_file, "r") as stream:
+        try:
+            initial_positions = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
     rviz_config_file = PathJoinSubstitution(
         [FindPackageShare(description_package), "rviz", "view_robot.rviz"]
     )
@@ -138,6 +153,7 @@ def generate_launch_description():
     joint_state_publisher_node = Node(
         package="joint_state_publisher_gui",
         executable="joint_state_publisher_gui",
+        parameters=[{"zeros": initial_positions}],
     )
     robot_state_publisher_node = Node(
         package="robot_state_publisher",
@@ -153,10 +169,6 @@ def generate_launch_description():
         arguments=["-d", rviz_config_file],
     )
 
-    nodes_to_start = [
-        joint_state_publisher_node,
-        robot_state_publisher_node,
-        rviz_node,
-    ]
+    nodes_to_start = [joint_state_publisher_node, robot_state_publisher_node, rviz_node]
 
     return LaunchDescription(declared_arguments + nodes_to_start)


### PR DESCRIPTION
As we have the config file in place already, anyway, we can also use the parameters.

There are a couple of things I don't like about this implementation:
 - Parsing the yaml file manually seems awkward to me. However, as far as I understood, passing parameter files to nodes only supports yaml files following a certain syntax, which the `initial_positions.yaml` is not. (See possible workaround 1)
 - I could not manage to make the actual filename configurable as using a `LaunchConfiguration` object. But that might just be me being stupid.

**Possible workaround 1: Include separate file**
With defining a separate file with content
```yaml
joint_state_publisher:
  ros__parameters:
    zeros:
      shoulder_pan_joint: 0.0
      shoulder_lift_joint: -1.57
      elbow_joint: 0.0
      wrist_1_joint: -1.57
      wrist_2_joint: 0.0
      wrist_3_joint: 0.0
```
we could pass that file to the node directly. However, this would be config duplication.

As I couldn't come up with a better solution, I postet a question on ROS answers: https://answers.ros.org/question/396653/ros2-python-launchfile-load-parametersyaml-into-nodes-parameter/