### PR TITLE
Support custom ROS2 `system_interfaces`

### DIFF
--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -38,6 +38,7 @@
 
      <!-- Simulation parameters -->
    <xacro:arg name="use_fake_hardware" default="false" />
+   <xacro:arg name="use_custom_simulator" default="false" />
    <xacro:arg name="fake_sensor_commands" default="false" />
    <xacro:arg name="sim_gazebo" default="false" />
    <xacro:arg name="sim_ignition" default="false" />
@@ -66,6 +67,7 @@
      safety_pos_margin="$(arg safety_pos_margin)"
      safety_k_position="$(arg safety_k_position)"
      use_fake_hardware="$(arg use_fake_hardware)"
+     use_custom_simulator="$(arg use_custom_simulator)"
      fake_sensor_commands="$(arg fake_sensor_commands)"
      sim_gazebo="$(arg sim_gazebo)"
      sim_ignition="$(arg sim_ignition)"

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -67,6 +67,7 @@
     safety_pos_margin:=0.15
     safety_k_position:=20
     use_fake_hardware:=false
+    use_custom_simulator:=false
     fake_sensor_commands:=false
     sim_gazebo:=false
     sim_ignition:=false
@@ -97,35 +98,40 @@
       force_abs_paths="${sim_gazebo or sim_ignition}"/>
 
 
-    <!-- ros2 control include -->
-    <xacro:include filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
-    <!-- ros2 control instance -->
-    <xacro:ur_ros2_control
-      name="${name}" prefix="${prefix}"
-      use_fake_hardware="${use_fake_hardware}"
-      initial_positions="${initial_positions}"
-      fake_sensor_commands="${fake_sensor_commands}"
-      headless_mode="${headless_mode}"
-      sim_gazebo="${sim_gazebo}"
-      sim_ignition="${sim_ignition}"
-      script_filename="${script_filename}"
-      output_recipe_filename="${output_recipe_filename}"
-      input_recipe_filename="${input_recipe_filename}"
-      tf_prefix=""
-      hash_kinematics="${kinematics_hash}"
-      robot_ip="${robot_ip}"
-      use_tool_communication="${use_tool_communication}"
-      tool_voltage="${tool_voltage}"
-      tool_parity="${tool_parity}"
-      tool_baud_rate="${tool_baud_rate}"
-      tool_stop_bits="${tool_stop_bits}"
-      tool_rx_idle_chars="${tool_rx_idle_chars}"
-      tool_tx_idle_chars="${tool_tx_idle_chars}"
-      tool_device_name="${tool_device_name}"
-      tool_tcp_port="${tool_tcp_port}"
-      reverse_port="${reverse_port}"
-      script_sender_port="${script_sender_port}"
-      />
+    <!-- Support custom simulators.
+    Users can specify their ros2_control and hardware tags inside their own robot description.
+    This allows them to implement their own system_interface. -->
+    <xacro:unless value="${use_custom_simulator}">
+      <!-- ros2 control include -->
+      <xacro:include filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
+      <!-- ros2 control instance -->
+      <xacro:ur_ros2_control
+        name="${name}" prefix="${prefix}"
+        use_fake_hardware="${use_fake_hardware}"
+        initial_positions="${initial_positions}"
+        fake_sensor_commands="${fake_sensor_commands}"
+        headless_mode="${headless_mode}"
+        sim_gazebo="${sim_gazebo}"
+        sim_ignition="${sim_ignition}"
+        script_filename="${script_filename}"
+        output_recipe_filename="${output_recipe_filename}"
+        input_recipe_filename="${input_recipe_filename}"
+        tf_prefix=""
+        hash_kinematics="${kinematics_hash}"
+        robot_ip="${robot_ip}"
+        use_tool_communication="${use_tool_communication}"
+        tool_voltage="${tool_voltage}"
+        tool_parity="${tool_parity}"
+        tool_baud_rate="${tool_baud_rate}"
+        tool_stop_bits="${tool_stop_bits}"
+        tool_rx_idle_chars="${tool_rx_idle_chars}"
+        tool_tx_idle_chars="${tool_tx_idle_chars}"
+        tool_device_name="${tool_device_name}"
+        tool_tcp_port="${tool_tcp_port}"
+        reverse_port="${reverse_port}"
+        script_sender_port="${script_sender_port}"
+        />
+    </xacro:unless>
 
     <!-- Add URDF transmission elements (for ros_control) -->
     <!--<xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />-->


### PR DESCRIPTION
## Goal
By setting the `use_custom_simulator` parameter, users can specify their
own `ros2_control` and `hardware` tags inside their robot description.

## Motivation
This allows users to implement their own simulators with custom `system_interfaces`. I came across this necessity while implementing a [MuJoCo](https://github.com/deepmind/mujoco)-based `system_interface`. I couldn't find a way to do that with the current [choice of *simulators*](https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/ros2/urdf/ur.ros2_control.xacro#L23) inside the xacro macros.

## Example usage
Here's a use case with a custom UR5e:
```xml
<?xml version="1.0"?>
<robot name="robot" xmlns:xacro="http://ros.org/wiki/xacro">

        <!-- Parameters are passed to the includes -->
        <xacro:arg name="name" default="ur5e"/>
        <xacro:arg name="ur_type" default="ur5e"/>
        <xacro:arg name="use_custom_simulator" default="true"/>
        <xacro:arg name="prefix" default=""/>

        <!-- Includes -->
        <xacro:include filename="$(find ur_description)/urdf/ur.urdf.xacro"/>
        <xacro:include filename="$(find my_example_project)/urdf/joint_interface.xacro"/>

        <!-- The robot is connected to world by default -->

        <!-- We add our own MuJoCo-based simulator -->
        <ros2_control name="ur5e" type="system">
                <xacro:joint_interface name="shoulder_pan_joint" p="1000" d="100"/>
                <xacro:joint_interface name="shoulder_lift_joint" p="1000" d="100"/>
                <xacro:joint_interface name="elbow_joint" p="1000" d="50"/>
                <xacro:joint_interface name="wrist_1_joint" p="500" d="10"/>
                <xacro:joint_interface name="wrist_2_joint" p="50" d="1"/>
                <xacro:joint_interface name="wrist_3_joint" p="50" d="0.01"/>
                <hardware>
                        <plugin>my_example_project/Simulator</plugin>
                        <param name="mujoco_model">$(arg mujoco_model)</param>
                        <param name="mesh_directory">$(arg mesh_directory)</param>
                </hardware>
        </ros2_control>

</robot>
```
And here's the joint macro:
```xml
<?xml version="1.0"?>
<robot xmlns:xacro="http://www.ros.org/wiki/xacro">

        <!-- Individual joint. -->
        <xacro:macro name="joint_interface" params="name p d">
                <joint name="${name}">
                        <param name="p">${p}</param>
                        <param name="d">${d}</param>
                        <command_interface name="position"/>
                        <command_interface name="velocity"/>
                        <command_interface name="effort"/>
                        <state_interface name="position"/>
                        <state_interface name="velocity"/>
                        <state_interface name="effort"/>
                </joint>
        </xacro:macro>

</robot>
```