### PR TITLE
fake_components -> mock_components

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -27,7 +27,7 @@
           <plugin>ign_ros2_control/IgnitionSystem</plugin>
         </xacro:if>
         <xacro:if value="${use_fake_hardware}">
-          <plugin>fake_components/GenericSystem</plugin>
+          <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>


### PR DESCRIPTION
This was caused by a change in ros2_control: https://github.com/ros-controls/ros2_control/commit/1967cfa179248ce2e72f4f974f20d6e19fe56da4

I need this change to work with fake hardware.