### PR TITLE
Set the default tool voltage in the description to 0

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -13,7 +13,7 @@
     script_filename output_recipe_filename
     input_recipe_filename tf_prefix
     hash_kinematics robot_ip
-    tool_voltage:=24 tool_parity:=0 tool_baud_rate:=115200 tool_stop_bits:=1
+    tool_voltage:=0 tool_parity:=0 tool_baud_rate:=115200 tool_stop_bits:=1
     tool_rx_idle_chars:=1.5 tool_tx_idle_chars:=3.5 tool_device_name:=/tmp/ttyUR tool_tcp_port:=54321
     reverse_port:=50001
     script_sender_port:=50002

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -29,7 +29,7 @@
    <xacro:arg name="script_command_port" default="50004"/>
    <!--   tool communication related parameters-->
    <xacro:arg name="use_tool_communication" default="false" />
-   <xacro:arg name="tool_voltage" default="24" />
+   <xacro:arg name="tool_voltage" default="0" />
    <xacro:arg name="tool_parity" default="0" />
    <xacro:arg name="tool_baud_rate" default="115200" />
    <xacro:arg name="tool_stop_bits" default="1" />

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -73,7 +73,7 @@
     headless_mode:=false
     initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}
     use_tool_communication:=false
-    tool_voltage:=24
+    tool_voltage:=0
     tool_parity:=0
     tool_baud_rate:=115200
     tool_stop_bits:=1


### PR DESCRIPTION
I am not sure whether this will actually affect something, as I don't think we actually set the value initially, but it still makes sense to keep the default tool voltage at 0 to emphasize that by default, this will not be set higher.

This accompanies https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/526