### PR TITLE
Change `load_yaml` to `xacro.load_yaml` after former was deprecated

### DIFF
--- a/urdf/inc/ur_common.xacro
+++ b/urdf/inc/ur_common.xacro
@@ -45,10 +45,10 @@
 
     <xacro:property name="force_abs_paths" value="${force_abs_paths}" scope="parent"/>
     <!-- Read .yaml files from disk, load content into properties -->
-    <xacro:property name="config_joint_limit_parameters" value="${load_yaml(joint_limits_parameters_file)}"/>
-    <xacro:property name="config_kinematics_parameters" value="${load_yaml(kinematics_parameters_file)}"/>
-    <xacro:property name="config_physical_parameters" value="${load_yaml(physical_parameters_file)}"/>
-    <xacro:property name="config_visual_parameters" value="${load_yaml(visual_parameters_file)}"/>
+    <xacro:property name="config_joint_limit_parameters" value="${xacro.load_yaml(joint_limits_parameters_file)}"/>
+    <xacro:property name="config_kinematics_parameters" value="${xacro.load_yaml(kinematics_parameters_file)}"/>
+    <xacro:property name="config_physical_parameters" value="${xacro.load_yaml(physical_parameters_file)}"/>
+    <xacro:property name="config_visual_parameters" value="${xacro.load_yaml(visual_parameters_file)}"/>
 
     <!-- Extract subsections from yaml dictionaries -->
     <xacro:property name="sec_limits" value="${config_joint_limit_parameters['joint_limits']}"/>

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -70,7 +70,7 @@
      sim_gazebo="$(arg sim_gazebo)"
      sim_ignition="$(arg sim_ignition)"
      headless_mode="$(arg headless_mode)"
-     initial_positions="${load_yaml(initial_positions_file)}"
+     initial_positions="${xacro.load_yaml(initial_positions_file)}"
      use_tool_communication="$(arg use_tool_communication)"
      tool_voltage="$(arg tool_voltage)"
      tool_parity="$(arg tool_parity)"


### PR DESCRIPTION
Avoids following error and allows URDF to load. Without this change, UR URDF can no longer be loaded into ROS packages

```
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
```