### PR TITLE
Run prerelease tests on current distros

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [galactic]
+        ROS_DISTRO: [humble, rolling]
         ROS_REPO: [main]
         PRERELEASE: [true]
     env:


### PR DESCRIPTION
Since galactic is now outdated, especially on the default branch.