### PR TITLE
Ignition to Gz migration

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -6,7 +6,7 @@
     prefix
     use_fake_hardware:=false fake_sensor_commands:=false
     sim_gazebo:=false
-    sim_ignition:=false
+    sim_gz:=false
     headless_mode:=false
     initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}
     use_tool_communication:=false
@@ -25,15 +25,15 @@
         <xacro:if value="${sim_gazebo}">
           <plugin>gazebo_ros2_control/GazeboSystem</plugin>
         </xacro:if>
-        <xacro:if value="${sim_ignition}">
-          <plugin>ign_ros2_control/IgnitionSystem</plugin>
+        <xacro:if value="${sim_gz}">
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:if value="${use_fake_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_ignition}">
+        <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_gz}">
           <plugin>ur_robot_driver/URPositionHardwareInterface</plugin>
           <param name="robot_ip">${robot_ip}</param>
           <param name="script_filename">${script_filename}</param>
@@ -157,7 +157,7 @@
         <state_interface name="effort"/>
       </joint>
 
-      <xacro:unless value="${sim_gazebo or sim_ignition}">
+      <xacro:unless value="${sim_gazebo or sim_gz}">
         <sensor name="tcp_fts_sensor">
           <state_interface name="force.x"/>
           <state_interface name="force.y"/>

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -42,7 +42,7 @@
    <xacro:arg name="use_fake_hardware" default="false" />
    <xacro:arg name="fake_sensor_commands" default="false" />
    <xacro:arg name="sim_gazebo" default="false" />
-   <xacro:arg name="sim_ignition" default="false" />
+   <xacro:arg name="sim_gz" default="false" />
    <xacro:arg name="simulation_controllers" default="" />
 
    <!-- initial position for simulations (Fake Hardware, Gazebo, Ignition) -->
@@ -70,7 +70,7 @@
      use_fake_hardware="$(arg use_fake_hardware)"
      fake_sensor_commands="$(arg fake_sensor_commands)"
      sim_gazebo="$(arg sim_gazebo)"
-     sim_ignition="$(arg sim_ignition)"
+     sim_gz="$(arg sim_gz)"
      headless_mode="$(arg headless_mode)"
      initial_positions="${xacro.load_yaml(initial_positions_file)}"
      use_tool_communication="$(arg use_tool_communication)"
@@ -103,12 +103,12 @@
     </gazebo>
   </xacro:if>
 
-  <xacro:if value="$(arg sim_ignition)">
+  <xacro:if value="$(arg sim_gz)">
     <!-- Gazebo plugins -->
     <gazebo reference="world">
     </gazebo>
     <gazebo>
-      <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+      <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
         <parameters>$(arg simulation_controllers)</parameters>
         <controller_manager_node_name>$(arg prefix)controller_manager</controller_manager_node_name>
       </plugin>

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -69,7 +69,7 @@
     use_fake_hardware:=false
     fake_sensor_commands:=false
     sim_gazebo:=false
-    sim_ignition:=false
+    sim_gz:=false
     headless_mode:=false
     initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}
     use_tool_communication:=false
@@ -96,7 +96,7 @@
       kinematics_parameters_file="${kinematics_parameters_file}"
       physical_parameters_file="${physical_parameters_file}"
       visual_parameters_file="${visual_parameters_file}"
-      force_abs_paths="${sim_gazebo or sim_ignition}"/>
+      force_abs_paths="${sim_gazebo or sim_gz}"/>
 
 
     <!-- ros2 control include -->
@@ -109,7 +109,7 @@
       fake_sensor_commands="${fake_sensor_commands}"
       headless_mode="${headless_mode}"
       sim_gazebo="${sim_gazebo}"
-      sim_ignition="${sim_ignition}"
+      sim_gz="${sim_gz}"
       script_filename="${script_filename}"
       output_recipe_filename="${output_recipe_filename}"
       input_recipe_filename="${input_recipe_filename}"


### PR DESCRIPTION
The xacro files updated to match the latest gz ros2 control notation and code. Changes have been tested on ROS 2 rolling and gazebo garden.