### PR TITLE
Add conditional joint friction to stabilize Gazebo Classic simulation.

### DIFF
--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -278,6 +278,7 @@
       -->
       <origin xyz="0 0 0" rpy="0 0 ${pi}" />
     </joint>
+    <!-- Conditional dynamics tags set the joint friction to 100x the joint's effort limit per discussion at Universal_Robots_ROS2_Gazebo_Simulation/issues/19 -->
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link_inertia" />
       <child link="${prefix}shoulder_link" />
@@ -288,7 +289,7 @@
       <xacro:if value="${safety_limits}">
          <safety_controller soft_lower_limit="${shoulder_pan_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_pan_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
-      <dynamics damping="0" friction="0"/>
+      <dynamics damping="0" friction="${shoulder_pan_effort_limit*100.0 if sim_gazebo else 0}"/>
     </joint>
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
@@ -300,7 +301,7 @@
       <xacro:if value="${safety_limits}">
          <safety_controller soft_lower_limit="${shoulder_lift_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_lift_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
-      <dynamics damping="0" friction="0"/>
+      <dynamics damping="0" friction="${shoulder_lift_effort_limit*100.0 if sim_gazebo else 0}"/>
     </joint>
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
@@ -312,7 +313,7 @@
       <xacro:if value="${safety_limits}">
          <safety_controller soft_lower_limit="${elbow_joint_lower_limit + safety_pos_margin}" soft_upper_limit="${elbow_joint_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
-      <dynamics damping="0" friction="0"/>
+      <dynamics damping="0" friction="${elbow_joint_effort_limit*100.0 if sim_gazebo else 0}"/>
     </joint>
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
@@ -324,7 +325,7 @@
       <xacro:if value="${safety_limits}">
          <safety_controller soft_lower_limit="${wrist_1_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_1_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
-      <dynamics damping="0" friction="0"/>
+      <dynamics damping="0" friction="${wrist_1_effort_limit*100.0 if sim_gazebo else 0}"/>
     </joint>
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
@@ -336,7 +337,7 @@
       <xacro:if value="${safety_limits}">
          <safety_controller soft_lower_limit="${wrist_2_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_2_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
-      <dynamics damping="0" friction="0"/>
+      <dynamics damping="0" friction="${wrist_2_effort_limit*100.0 if sim_gazebo else 0}"/>
     </joint>
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
@@ -348,7 +349,7 @@
       <xacro:if value="${safety_limits}">
          <safety_controller soft_lower_limit="${wrist_3_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_3_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
-      <dynamics damping="0" friction="0"/>
+      <dynamics damping="0" friction="${wrist_3_effort_limit*100.0 if sim_gazebo else 0}"/>
     </joint>
 
     <link name="${prefix}ft_frame"/>


### PR DESCRIPTION
This PR follows on the discussion at https://github.com/UniversalRobots/Universal_Robots_ROS2_Gazebo_Simulation/issues/19 

## Summary

Simulated UR robots in Gazebo Classic in ROS 2 are not stable as described in the issue above.

This PR stabilizes that behavior (only tested with ODE so far) by adding friction in the joints' `<dynamics>` tags if `sim_gazebo` is true. 

## Details

There are a few discussions of similar issues I've found. In particular [gazebo_ros2_control/issues/54](https://github.com/ros-controls/gazebo_ros2_control/issues/54 ) suggests a couple of different approaches:

- Explicitly calling the joints' `SetParam()` method in source code to set the `fmax` parameter, as suggested [here](https://github.com/ros-controls/gazebo_ros2_control/issues/54#issuecomment-775580231) (also suggesting that `joint_limits_interface` might handle this at some point)
- Adding damping and friction (and ensuring all nodes use simulated time), as suggested [here](https://github.com/ros-controls/gazebo_ros2_control/issues/54#issuecomment-890160708).

In the end, both of these suggestions appear to achieve the same thing for position- and velocity- controlled joints:

- In Open Dynamics Engine in ROS 1, the joints' `fmax` parameter (`dParamFMax` in Gazebo source code, see [here](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/physics/ode/ODEJoint.cc#L440)) was set explicitly by a function call in `gazebo_ros_control` [here](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/noetic-devel/gazebo_ros_control/src/default_robot_hw_sim.cpp#L240) if the joints used position or velocity command interfaces.
- In ODE, it appears that the friction parameter is also used to set `dParamFMax`, see [here](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/physics/ode/ODEJoint.cc#L444). Empirically, that does seem to be what happens when I pass friction through a joint `<dynamics>` tag like I do in this PR.

In this PR I set the "friction" to 100x the maximum joint effort for reasons suggested [here](https://github.com/UniversalRobots/Universal_Robots_ROS2_Gazebo_Simulation/issues/19#issuecomment-1481372879). In short, it seems that `dParamFMax` is a mathematical parameter more than something which should be usually set to a physical joint parameter. 

[The ODE manual](http://ode.org/wiki/index.php/Manual#Stops_and_motor_parameters) says this about joint motors:

> Motors have two parameters: a desired speed, and the maximum force that is available to reach that speed. This is a very simple model of real life motors, engines or servos. However, is it quite useful when modeling a motor (or engine or servo) that is geared down with a gearbox before being connected to the joint. Such devices are often controlled by setting a desired speed, and can only generate a maximum amount of power to achieve that speed (which corresponds to a certain amount of force available at the joint).

This describes a geared motor with no supervision operating at its stall torque, but I wouldn't characterize the UR's joints that way. I believe the robot will fault well before it slows down to limit itself at some max torque.

## Limitations

If the UR ROS 2 Gazebo simulation ever evolves toward supporting `EffortJointInterface` like [universal_robot/issues/521](https://github.com/ros-industrial/universal_robot/issues/521), then injecting friction through the robot description would appear to violate the guidance in [this comment](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/noetic-devel/gazebo_ros_control/src/default_robot_hw_sim.cpp#L237). That said, if `gazebo_ros2_control` eventually handles this, I'd think it'd be better to appropriately reset the joints if possible.

Also, an effort command interface is only useful in simulation, since the real robot can't accept joint-level effort commands. 

I also haven't tried to test this against the other physics engines yet. I'd currently expect:

- It's a problem in DART, see [here](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/physics/dart/DARTJoint.cc#L576).
- It'd be neutral in Bullet, see [here](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/physics/bullet/BulletJoint.cc#L566) if `JointPtr->SetParam()` is called, and [here](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/physics/bullet/BulletJoint.cc#L85) if it describes `<axis>` friction.
- It'd be neutral in Simbody, see [here](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/physics/simbody/SimbodyJoint.cc#L485) if `JointPtr->SetParam()` is called and [here](https://github.com/gazebosim/gazebo-classic/blob/gazebo11/gazebo/physics/simbody/SimbodyJoint.cc#L70) if an `<axis>` element is parsed.

However I don't understand enough about Gazebo and the URDF->SDF->In-Memory Joint pipeline to know if that's where the `<dynamics>` tag ends up.

## Questions

This PR seems to provide an expedient fix for [ur_simulation_gazebo/issues/19](https://github.com/UniversalRobots/Universal_Robots_ROS2_Gazebo_Simulation/issues/19) but I'm not sure it's the right approach. I'm wondering:

- Is `ur_description` intended to support other physics engines besides ODE when used in the context of `ur_simulation_gazebo`? 
- Are there eventual plans, either here in `ur_description` or in the simulation packages to support effort joint interfaces like [universal_robot/issues/521](https://github.com/ros-industrial/universal_robot/issues/521)?
