### PR TITLE
Workaround: Prefix an _ to the tf_prefix to allow empty prefixes

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -48,7 +48,7 @@
           <param name="reverse_ip">${reverse_ip}</param>
           <param name="script_command_port">${script_command_port}</param>
           <param name="trajectory_port">${trajectory_port}</param>
-          <param name="tf_prefix">${tf_prefix}</param>
+          <param name="tf_prefix">_${tf_prefix}</param>
           <param name="non_blocking_read">${non_blocking_read}</param>
           <param name="servoj_gain">2000</param>
           <param name="servoj_lookahead_time">0.03</param>


### PR DESCRIPTION
Currently, the hardware interface does not support empty parameters (see https://github.com/ros-controls/ros2_control/issues/994). Hence, we use a workaround by prefixing something to the tf_prefix that we can later remove inside the hardware_interface.

This implements a suggestion from @firesurfer (https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/633#issuecomment-1516031750) until we've sorted out how https://github.com/ros-controls/ros2_control/issues/994 progresses.