### PR TITLE
Add acceleration limits to all robot configs

### DIFF
--- a/config/ur10/joint_limits.yaml
+++ b/config/ur10/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 150.0
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0

--- a/config/ur10e/joint_limits.yaml
+++ b/config/ur10e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 150.0
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0

--- a/config/ur16e/joint_limits.yaml
+++ b/config/ur16e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 150.0
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0

--- a/config/ur3/joint_limits.yaml
+++ b/config/ur3/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 28.0
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0

--- a/config/ur3e/joint_limits.yaml
+++ b/config/ur3e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 28.0
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0

--- a/config/ur5/joint_limits.yaml
+++ b/config/ur5/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
     max_effort: 150.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,51 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
-    min_position: !degrees -180.0
-  wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
+    min_position: !degrees -180.0
+    max_position: !degrees  180.0
     has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
     max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
+  wrist_1_joint:
+    has_position_limits: true
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_2_joint:
     # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0

--- a/config/ur5e/joint_limits.yaml
+++ b/config/ur5e/joint_limits.yaml
@@ -17,7 +17,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
   shoulder_lift_joint:
@@ -29,7 +29,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
   elbow_joint:
@@ -51,7 +51,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
   wrist_1_joint:
@@ -63,7 +63,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
   wrist_2_joint:
@@ -76,7 +76,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
   wrist_3_joint:
@@ -88,6 +88,6 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0

--- a/config/ur5e/joint_limits.yaml
+++ b/config/ur5e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 150.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
     max_effort: 150.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,51 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
-    min_position: !degrees -180.0
-  wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
+    min_position: !degrees -180.0
+    max_position: !degrees  180.0
     has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
     max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 150.0
+  wrist_1_joint:
+    has_position_limits: true
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_2_joint:
     # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 28.0


### PR DESCRIPTION
Based on the discussion in https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/46, MoveIt 2 now requires defined acceleration limits for the Time-Optimal Trajectory Generation (TOTG) adapter to function correctly.

This adds acceleration limits of 5.0 rad/s^2 to all joints, which I'm happy to change if we have something more up-to-date to use.

I also rearranged the structure of the limits to be a bit easier to read and modify, and submitted https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/639 so the joint limits are loaded from the config file.

Closes https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/46