### PR TITLE
Reorder joint limits

### DIFF
--- a/config/ur10/joint_limits.yaml
+++ b/config/ur10/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 150.0
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0

--- a/config/ur10/joint_limits.yaml
+++ b/config/ur10/joint_limits.yaml
@@ -14,9 +14,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  120.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 330.0
@@ -26,9 +25,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  120.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 330.0
@@ -48,9 +46,8 @@ joint_limits:
     max_position: !degrees  180.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -60,9 +57,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -72,9 +68,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -84,9 +79,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0

--- a/config/ur10e/joint_limits.yaml
+++ b/config/ur10e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 150.0
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0

--- a/config/ur10e/joint_limits.yaml
+++ b/config/ur10e/joint_limits.yaml
@@ -14,9 +14,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  120.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 330.0
@@ -26,9 +25,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  120.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 330.0
@@ -48,9 +46,8 @@ joint_limits:
     max_position: !degrees  180.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -60,9 +57,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -72,9 +68,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -84,9 +79,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0

--- a/config/ur16e/joint_limits.yaml
+++ b/config/ur16e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 330.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  120.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 150.0
+    max_velocity: !degrees  120.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 330.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0

--- a/config/ur16e/joint_limits.yaml
+++ b/config/ur16e/joint_limits.yaml
@@ -14,9 +14,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  120.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 330.0
@@ -26,9 +25,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  120.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 330.0
@@ -48,9 +46,8 @@ joint_limits:
     max_position: !degrees  180.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -60,9 +57,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -72,9 +68,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -84,9 +79,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0

--- a/config/ur3/joint_limits.yaml
+++ b/config/ur3/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 28.0
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0

--- a/config/ur3/joint_limits.yaml
+++ b/config/ur3/joint_limits.yaml
@@ -14,10 +14,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
-    max_acceleration: 5.0
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     has_effort_limits: true
     max_effort: 56.0
   shoulder_lift_joint:
@@ -26,9 +24,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -48,9 +45,8 @@ joint_limits:
     max_position: !degrees  180.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
@@ -60,9 +56,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  360.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 12.0
@@ -72,9 +67,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  360.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 12.0
@@ -84,9 +78,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  360.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 12.0

--- a/config/ur3e/joint_limits.yaml
+++ b/config/ur3e/joint_limits.yaml
@@ -14,9 +14,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -26,9 +25,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 56.0
@@ -48,9 +46,8 @@ joint_limits:
     max_position: !degrees  180.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
@@ -60,9 +57,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  360.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 12.0
@@ -72,9 +68,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  360.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 12.0
@@ -84,9 +79,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  360.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 12.0

--- a/config/ur3e/joint_limits.yaml
+++ b/config/ur3e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 56.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
-    max_effort: 28.0
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 56.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,50 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
+    has_position_limits: true
     min_position: !degrees -180.0
+    max_position: !degrees  180.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_2_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 12.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  360.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  360.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 12.0

--- a/config/ur5/joint_limits.yaml
+++ b/config/ur5/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
     max_effort: 150.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,51 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
-    min_position: !degrees -180.0
-  wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
+    min_position: !degrees -180.0
+    max_position: !degrees  180.0
     has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
     max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 150.0
+  wrist_1_joint:
+    has_position_limits: true
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_2_joint:
     # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+    has_effort_limits: true
+    max_effort: 28.0

--- a/config/ur5/joint_limits.yaml
+++ b/config/ur5/joint_limits.yaml
@@ -14,9 +14,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -26,9 +25,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -48,9 +46,8 @@ joint_limits:
     max_position: !degrees  180.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -60,9 +57,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
@@ -73,9 +69,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
@@ -85,9 +80,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0

--- a/config/ur5e/joint_limits.yaml
+++ b/config/ur5e/joint_limits.yaml
@@ -17,7 +17,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
   shoulder_lift_joint:
@@ -29,7 +29,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
   elbow_joint:
@@ -51,7 +51,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
   wrist_1_joint:
@@ -63,7 +63,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
   wrist_2_joint:
@@ -76,7 +76,7 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
   wrist_3_joint:
@@ -88,6 +88,6 @@ joint_limits:
     # Acceleration limits are not publicly available, but needed
     # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
     has_acceleration_limits: true
-    max_acceleration: !degrees 180.0
+    max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0

--- a/config/ur5e/joint_limits.yaml
+++ b/config/ur5e/joint_limits.yaml
@@ -9,32 +9,30 @@
 #    retrieved: 2020-06-16, last modified: 2020-06-09
 joint_limits:
   shoulder_pan_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 150.0
   shoulder_lift_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 150.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
-  elbow_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
-    has_position_limits: true
+    max_position: !degrees  360.0
     has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
     max_effort: 150.0
+  elbow_joint:
     # we artificially limit this joint to half its actual joint position limit
     # to avoid (MoveIt/OMPL) planning problems, as due to the physical
     # construction of the robot, it's impossible to rotate the 'elbow_joint'
@@ -45,36 +43,51 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: !degrees  180.0
-    max_velocity: !degrees  180.0
-    min_position: !degrees -180.0
-  wrist_1_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
+    min_position: !degrees -180.0
+    max_position: !degrees  180.0
     has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
     max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 150.0
+  wrist_1_joint:
+    has_position_limits: true
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_2_joint:
     # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 28.0
   wrist_3_joint:
-    # acceleration limits are not publicly available
-    has_acceleration_limits: false
-    has_effort_limits: true
     has_position_limits: true
-    has_velocity_limits: true
-    max_effort: 28.0
-    max_position: !degrees  360.0
-    max_velocity: !degrees  180.0
     min_position: !degrees -360.0
+    max_position: !degrees  360.0
+    has_velocity_limits: true
+    max_velocity: !degrees  180.0
+    # Acceleration limits are not publicly available, but needed
+    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
+    has_acceleration_limits: true
+    max_acceleration: !degrees 180.0
+    has_effort_limits: true
+    max_effort: 28.0

--- a/config/ur5e/joint_limits.yaml
+++ b/config/ur5e/joint_limits.yaml
@@ -14,9 +14,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -26,9 +25,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -48,9 +46,8 @@ joint_limits:
     max_position: !degrees  180.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 150.0
@@ -60,9 +57,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
@@ -73,9 +69,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0
@@ -85,9 +80,8 @@ joint_limits:
     max_position: !degrees  360.0
     has_velocity_limits: true
     max_velocity: !degrees  180.0
-    # Acceleration limits are not publicly available, but needed
-    # for Time Optimal Trajectory Generation (TOTG) in MoveIt.
-    has_acceleration_limits: true
+    # acceleration limits are not publicly available
+    has_acceleration_limits: false
     max_acceleration: 5.0
     has_effort_limits: true
     max_effort: 28.0


### PR DESCRIPTION
This is an alternative version of https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/62, which keeps the acceleration limits set to false (since this is done specifically for the MoveIt config).

In essence, this just reorders a bunch of parameters.