### PR TITLE
Add tool voltage and zero ft sensor to command interface - galactic backport (#38)

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -16,7 +16,9 @@
     tool_voltage:=24 tool_parity:=0 tool_baud_rate:=115200 tool_stop_bits:=1
     tool_rx_idle_chars:=1.5 tool_tx_idle_chars:=3.5 tool_device_name:=/tmp/ttyUR tool_tcp_port:=54321
     reverse_port:=50001
-    script_sender_port:=50002">
+    script_sender_port:=50002
+    reverse_ip:=0.0.0.0
+    script_command_port:=50004">
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -40,6 +42,8 @@
           <param name="headless_mode">${headless_mode}</param>
           <param name="reverse_port">${reverse_port}</param>
           <param name="script_sender_port">${script_sender_port}</param>
+          <param name="reverse_ip">${reverse_ip}</param>
+          <param name="script_command_port">${script_command_port}</param>
           <param name="tf_prefix">"${tf_prefix}"</param>
           <param name="non_blocking_read">0</param>
           <param name="servoj_gain">2000</param>
@@ -194,6 +198,8 @@
           <command_interface name="standard_analog_output_cmd_0"/>
           <command_interface name="standard_analog_output_cmd_1"/>
 
+          <command_interface name="tool_voltage_cmd"/>
+
           <command_interface name="io_async_success"/>
 
           <state_interface name="digital_output_0"/>
@@ -289,6 +295,11 @@
         <gpio name="resend_robot_program">
           <command_interface name="resend_robot_program_cmd"/>
           <command_interface name="resend_robot_program_async_success"/>
+        </gpio>
+
+        <gpio name="zero_ftsensor">
+          <command_interface name="zero_ftsensor_cmd"/>
+          <command_interface name="zero_ftsensor_async_success"/>
         </gpio>
 
         <gpio name="system_interface">

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -25,6 +25,8 @@
    <xacro:arg name="script_filename" default=""/>
    <xacro:arg name="output_recipe_filename" default=""/>
    <xacro:arg name="input_recipe_filename" default=""/>
+   <xacro:arg name="reverse_ip" default="0.0.0.0"/>
+   <xacro:arg name="script_command_port" default="50004"/>
    <!--   tool communication related parameters-->
    <xacro:arg name="use_tool_communication" default="false" />
    <xacro:arg name="tool_voltage" default="24" />
@@ -84,6 +86,8 @@
      script_filename="$(arg script_filename)"
      output_recipe_filename="$(arg output_recipe_filename)"
      input_recipe_filename="$(arg input_recipe_filename)"
+     reverse_ip="$(arg reverse_ip)"
+     script_command_port="$(arg script_command_port)"
      >
      <origin xyz="0 0 0" rpy="0 0 0" />          <!-- position robot in the world -->
    </xacro:ur_robot>

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -86,7 +86,9 @@
     output_recipe_filename:=to_be_filled_by_ur_robot_driver
     input_recipe_filename:=to_be_filled_by_ur_robot_driver
     reverse_port:=50001
-    script_sender_port:=50002">
+    script_sender_port:=50002
+    reverse_ip:=0.0.0.0
+    script_command_port:=50004">
 
     <!-- Load configuration data from the provided .yaml files -->
     <xacro:read_model_data
@@ -125,6 +127,8 @@
       tool_tcp_port="${tool_tcp_port}"
       reverse_port="${reverse_port}"
       script_sender_port="${script_sender_port}"
+      reverse_ip="${reverse_ip}"
+      script_command_port="${script_command_port}"
       />
 
     <!-- Add URDF transmission elements (for ros_control) -->


### PR DESCRIPTION
Added reverse ip and script command interface port as parameters.
Tested with hardware (UR5) and worked without error when set in remote control mode.

Backport to galactic. Goes with https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/707