### PR TITLE
Switch fake to mock for ros2_control updates

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -78,8 +78,12 @@
           <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${tf_prefix}shoulder_lift_joint">
         <command_interface name="position">
@@ -94,8 +98,12 @@
           <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${tf_prefix}elbow_joint">
         <command_interface name="position">
@@ -110,8 +118,12 @@
           <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['elbow_joint']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${tf_prefix}wrist_1_joint">
         <command_interface name="position">
@@ -126,8 +138,12 @@
           <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${tf_prefix}wrist_2_joint">
         <command_interface name="position">
@@ -142,8 +158,12 @@
           <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
       <joint name="${tf_prefix}wrist_3_joint">
         <command_interface name="position">
@@ -158,8 +178,12 @@
           <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['wrist_3_joint']}</param>
         </state_interface>
-        <state_interface name="velocity"/>
-        <state_interface name="effort"/>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="effort">
+          <param name="initial_value">0.0</param>
+        </state_interface>
       </joint>
 
       <xacro:unless value="${sim_gazebo or sim_ignition}">

--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="ur_ros2_control" params="
     name
-    use_fake_hardware:=false fake_sensor_commands:=false
+    use_mock_hardware:=false mock_sensor_commands:=false
     sim_gazebo:=false
     sim_ignition:=false
     headless_mode:=false
@@ -31,12 +31,12 @@
         <xacro:if value="${sim_ignition}">
           <plugin>ign_ros2_control/IgnitionSystem</plugin>
         </xacro:if>
-        <xacro:if value="${use_fake_hardware}">
+        <xacro:if value="${use_mock_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
-          <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+          <param name="mock_sensor_commands">${mock_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
-        <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_ignition}">
+        <xacro:unless value="${use_mock_hardware or sim_gazebo or sim_ignition}">
           <plugin>ur_robot_driver/URPositionHardwareInterface</plugin>
           <param name="robot_ip">${robot_ip}</param>
           <param name="script_filename">${script_filename}</param>
@@ -75,7 +75,7 @@
           <param name="max">3.15</param>
         </command_interface>
         <state_interface name="position">
-          <!-- initial position for the FakeSystem and simulation -->
+          <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
         </state_interface>
         <state_interface name="velocity"/>
@@ -91,7 +91,7 @@
           <param name="max">3.15</param>
         </command_interface>
         <state_interface name="position">
-          <!-- initial position for the FakeSystem and simulation -->
+          <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
         </state_interface>
         <state_interface name="velocity"/>
@@ -107,7 +107,7 @@
           <param name="max">3.15</param>
         </command_interface>
         <state_interface name="position">
-          <!-- initial position for the FakeSystem and simulation -->
+          <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['elbow_joint']}</param>
         </state_interface>
         <state_interface name="velocity"/>
@@ -123,7 +123,7 @@
           <param name="max">3.2</param>
         </command_interface>
         <state_interface name="position">
-          <!-- initial position for the FakeSystem and simulation -->
+          <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
         </state_interface>
         <state_interface name="velocity"/>
@@ -139,7 +139,7 @@
           <param name="max">3.2</param>
         </command_interface>
         <state_interface name="position">
-          <!-- initial position for the FakeSystem and simulation -->
+          <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
         </state_interface>
         <state_interface name="velocity"/>
@@ -155,7 +155,7 @@
           <param name="max">3.2</param>
         </command_interface>
         <state_interface name="position">
-          <!-- initial position for the FakeSystem and simulation -->
+          <!-- initial position for the mock system and simulation -->
           <param name="initial_value">${initial_positions['wrist_3_joint']}</param>
         </state_interface>
         <state_interface name="velocity"/>
@@ -172,7 +172,7 @@
           <state_interface name="torque.z"/>
         </sensor>
 
-        <!-- NOTE The following are joints used only for testing with fake hardware and will change in the future -->
+        <!-- NOTE The following are joints used only for testing with mock hardware and will change in the future -->
         <gpio name="${tf_prefix}speed_scaling">
           <state_interface name="speed_scaling_factor"/>
           <param name="initial_speed_scaling_factor">1</param>

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -39,13 +39,13 @@
    <xacro:arg name="tool_tcp_port" default="54321" />
 
      <!-- Simulation parameters -->
-   <xacro:arg name="use_fake_hardware" default="false" />
-   <xacro:arg name="fake_sensor_commands" default="false" />
+   <xacro:arg name="use_mock_hardware" default="false" />
+   <xacro:arg name="mock_sensor_commands" default="false" />
    <xacro:arg name="sim_gazebo" default="false" />
    <xacro:arg name="sim_ignition" default="false" />
    <xacro:arg name="simulation_controllers" default="" />
 
-   <!-- initial position for simulations (Fake Hardware, Gazebo, Ignition) -->
+   <!-- initial position for simulations (Mock Hardware, Gazebo, Ignition) -->
    <xacro:arg name="initial_positions_file" default="$(find ur_description)/config/initial_positions.yaml"/>
 
    <!-- convert to property to use substitution in function -->
@@ -67,8 +67,8 @@
      safety_limits="$(arg safety_limits)"
      safety_pos_margin="$(arg safety_pos_margin)"
      safety_k_position="$(arg safety_k_position)"
-     use_fake_hardware="$(arg use_fake_hardware)"
-     fake_sensor_commands="$(arg fake_sensor_commands)"
+     use_mock_hardware="$(arg use_mock_hardware)"
+     mock_sensor_commands="$(arg mock_sensor_commands)"
      sim_gazebo="$(arg sim_gazebo)"
      sim_ignition="$(arg sim_ignition)"
      headless_mode="$(arg headless_mode)"

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -66,8 +66,8 @@
     safety_limits:=false
     safety_pos_margin:=0.15
     safety_k_position:=20
-    use_fake_hardware:=false
-    fake_sensor_commands:=false
+    use_mock_hardware:=false
+    mock_sensor_commands:=false
     sim_gazebo:=false
     sim_ignition:=false
     headless_mode:=false
@@ -109,9 +109,9 @@
     <!-- ros2 control instance -->
     <xacro:ur_ros2_control
       name="${name}"
-      use_fake_hardware="${use_fake_hardware}"
+      use_mock_hardware="${use_mock_hardware}"
       initial_positions="${initial_positions}"
-      fake_sensor_commands="${fake_sensor_commands}"
+      mock_sensor_commands="${mock_sensor_commands}"
       headless_mode="${headless_mode}"
       sim_gazebo="${sim_gazebo}"
       sim_ignition="${sim_ignition}"


### PR DESCRIPTION
This PR updates "mock" to "fake" in the ros2_control parameters so it works correctly with the latest version (see linked issue).

Closes https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/76