### PR TITLE
Add mergify, dependabot and pre-commit update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Update actions in workflows weekly
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: Backport to humble branch
+    conditions:
+      - base=rolling
+      - label=backport-humble
+    actions:
+      backport:
+        branches:
+          - humble

--- a/.github/workflows/update-ci.yml
+++ b/.github/workflows/update-ci.yml
@@ -1,0 +1,42 @@
+# Auto-update CI tools regularly
+
+name: CI auto-update
+
+on:
+  schedule:
+    # Run weekly
+    - cron: '23 5 * * 0'
+  workflow_dispatch:
+
+jobs:
+  ci_auto_update:
+    name: CI auto-update
+    runs-on: ubuntu-latest
+    steps:
+      # Setup pre-commit
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.10.4
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      # Run update
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      # Create pull request
+      - name: Create pull-request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: update-ci/pre-commit-autoupdate
+          delete-branch: true
+          title: Auto-update pre-commit hooks
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          commit-message: Auto-update pre-commit hooks
+          labels: CI
+      - name: Check outputs
+        if: ${{ steps.cpr.pull-request-number }}
+        run: echo "Opened pull request ${{ steps.cpr.outputs.pull-request-number }} - ${{ steps.cpr.outputs.pull-request-url  }}"


### PR DESCRIPTION
This has been done on the driver already and is a great addition there.

Since the humble/iron branch is now different from the rolling branch we need to be able to backport things. Mergify is a great helper there. While being at it, I copied the other helpers from the driver's repo, as well.