### PR TITLE
Add a flange_pose_sensor to the ros2_control tag

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -196,6 +196,16 @@
           <state_interface name="torque.z"/>
         </sensor>
 
+        <sensor name="${tf_prefix}flange_pose_sensor">
+          <state_interface name="position.x"/>
+          <state_interface name="position.y"/>
+          <state_interface name="position.z"/>
+          <state_interface name="orientation.x"/>
+          <state_interface name="orientation.y"/>
+          <state_interface name="orientation.z"/>
+          <state_interface name="orientation.w"/>
+        </sensor>
+
         <!-- NOTE The following are joints used only for testing with mock hardware and will change in the future -->
         <gpio name="${tf_prefix}speed_scaling">
           <state_interface name="speed_scaling_factor"/>


### PR DESCRIPTION
Having the robot's flange pose as reported from the controller is a valuable thing for multiple reasons:

- We can publish the wrench at the correct pose
- We can easily verify correct tcp calibration
- The flange pose is invariant to configured tools on the TP

This should get merged together with https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/856