### PR TITLE
Default to non_blocking_read=true

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -19,7 +19,7 @@
     reverse_ip:=0.0.0.0
     script_command_port:=50004
     trajectory_port:=50003
-    non_blocking_read:=false
+    non_blocking_read:=true
     keep_alive_count:=2
     ">
 

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -90,7 +90,7 @@
     reverse_ip:=0.0.0.0
     script_command_port:=50004
     trajectory_port:=50003
-    non_blocking_read:=false
+    non_blocking_read:=true
     keep_alive_count:=2"
 
     >


### PR DESCRIPTION
Since non-blocking-read showed significantly more stable behavior, we should default to that. See https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/pull/615 for details.