### PR TITLE
Add "calculate_dynamics" mock_components parameter to urdf files

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="ur_ros2_control" params="
     name
-    use_fake_hardware:=false fake_sensor_commands:=false
+    use_fake_hardware:=false fake_sensor_commands:=false calculate_dynamics:=false
     sim_gazebo:=false
     sim_ignition:=false
     headless_mode:=false
@@ -34,6 +34,7 @@
         <xacro:if value="${use_fake_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+          <param name="calculate_dynamics">${calculate_dynamics}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_ignition}">

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -44,6 +44,7 @@
      <!-- Simulation parameters -->
    <xacro:arg name="use_fake_hardware" default="false" />
    <xacro:arg name="fake_sensor_commands" default="false" />
+   <xacro:arg name="calculate_dynamics" default="false" />
    <xacro:arg name="sim_gazebo" default="false" />
    <xacro:arg name="sim_ignition" default="false" />
    <xacro:arg name="simulation_controllers" default="" />
@@ -72,6 +73,7 @@
      safety_k_position="$(arg safety_k_position)"
      use_fake_hardware="$(arg use_fake_hardware)"
      fake_sensor_commands="$(arg fake_sensor_commands)"
+     calculate_dynamics="$(arg calculate_dynamics)"
      sim_gazebo="$(arg sim_gazebo)"
      sim_ignition="$(arg sim_ignition)"
      headless_mode="$(arg headless_mode)"

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -69,6 +69,7 @@
     safety_k_position:=20
     use_fake_hardware:=false
     fake_sensor_commands:=false
+    calculate_dynamics:=false
     sim_gazebo:=false
     sim_ignition:=false
     headless_mode:=false
@@ -114,6 +115,7 @@
         use_fake_hardware="${use_fake_hardware}"
         initial_positions="${initial_positions}"
         fake_sensor_commands="${fake_sensor_commands}"
+        calculate_dynamics="${calculate_dynamics}"
         headless_mode="${headless_mode}"
         sim_gazebo="${sim_gazebo}"
         sim_ignition="${sim_ignition}"


### PR DESCRIPTION
Since this recent ros2_control [commit](https://github.com/ros-controls/ros2_control/commit/bb17084f75849f643effb7ff58daa8db2bc53396), the MockHardware component has a `calculate_dynamics` functionnality to derive state values from available data. 
For instance, if only the position command interface is used, the velocity is automatically estimated by numerical derivation.
This feature is not yet used by the UR decription file, but only minor changes are required (see PR's modified files).
The only real change for the humble branch is in the ros2_control description:
```diff
...
<xacro:if value="${use_fake_hardware}">
  <plugin>mock_components/GenericSystem</plugin>
  <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+  <param name="calculate_dynamics">${calculate_dynamics}</param>
  <param name="state_following_offset">0.0</param>
</xacro:if>
...
```

Note: the PR is targeted at the humble branch, because the file structure has changed in the meantime (`ros2_control_mock_hardware.xacro` instead of `ur.ros2_control.xacro`), but the same applies to rolling/iron branches.