### PR TITLE
[CI] Fix ref for scheduled jazzy testing binary build

### DIFF
--- a/.github/workflows/jazzy-binary-testing.yml
+++ b/.github/workflows/jazzy-binary-testing.yml
@@ -19,4 +19,4 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: testing
-      ref_for_scheduled_build: jazzy
+      ref_for_scheduled_build: rolling


### PR DESCRIPTION
That was referring to a non-existing jazzy branch.