### PR TITLE
Remove limits definitions from ros2_control command interfaces

### DIFF
--- a/urdf/inc/ur_joint_control.xacro
+++ b/urdf/inc/ur_joint_control.xacro
@@ -1,18 +1,13 @@
 <?xml version="1.0"?>
+
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:macro name="ur_joint_control_description" params="
     tf_prefix
     initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}
     ">
     <joint name="${tf_prefix}shoulder_pan_joint">
-      <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
-      </command_interface>
-      <command_interface name="velocity">
-        <param name="min">-3.15</param>
-        <param name="max">3.15</param>
-      </command_interface>
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
@@ -25,14 +20,8 @@
       </state_interface>
     </joint>
     <joint name="${tf_prefix}shoulder_lift_joint">
-      <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
-      </command_interface>
-      <command_interface name="velocity">
-        <param name="min">-3.15</param>
-        <param name="max">3.15</param>
-      </command_interface>
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
@@ -45,14 +34,8 @@
       </state_interface>
     </joint>
     <joint name="${tf_prefix}elbow_joint">
-      <command_interface name="position">
-        <param name="min">{-pi}</param>
-        <param name="max">{pi}</param>
-      </command_interface>
-      <command_interface name="velocity">
-        <param name="min">-3.15</param>
-        <param name="max">3.15</param>
-      </command_interface>
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['elbow_joint']}</param>
@@ -65,14 +48,8 @@
       </state_interface>
     </joint>
     <joint name="${tf_prefix}wrist_1_joint">
-      <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
-      </command_interface>
-      <command_interface name="velocity">
-        <param name="min">-3.2</param>
-        <param name="max">3.2</param>
-      </command_interface>
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
@@ -85,14 +62,8 @@
       </state_interface>
     </joint>
     <joint name="${tf_prefix}wrist_2_joint">
-      <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
-      </command_interface>
-      <command_interface name="velocity">
-        <param name="min">-3.2</param>
-        <param name="max">3.2</param>
-      </command_interface>
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
@@ -105,14 +76,8 @@
       </state_interface>
     </joint>
     <joint name="${tf_prefix}wrist_3_joint">
-      <command_interface name="position">
-        <param name="min">{-2*pi}</param>
-        <param name="max">{2*pi}</param>
-      </command_interface>
-      <command_interface name="velocity">
-        <param name="min">-3.2</param>
-        <param name="max">3.2</param>
-      </command_interface>
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['wrist_3_joint']}</param>


### PR DESCRIPTION
The controller manager's limit parser considers the limits from the URDF now. Removing this superfluous definitions should improve clarity.


Since the CM is also actually picking up the limits from the ros2_control tags we get warnings when starting up, since the fields were missing a dollar sign for the calculations, anyway.