### PR TITLE
Remove ros2_control limit params

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -66,14 +66,8 @@
         </xacro:unless>
       </hardware>
       <joint name="${tf_prefix}shoulder_pan_joint">
-        <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
-        </command_interface>
-        <command_interface name="velocity">
-          <param name="min">-3.15</param>
-          <param name="max">3.15</param>
-        </command_interface>
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
@@ -82,14 +76,8 @@
         <state_interface name="effort"/>
       </joint>
       <joint name="${tf_prefix}shoulder_lift_joint">
-        <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
-        </command_interface>
-        <command_interface name="velocity">
-          <param name="min">-3.15</param>
-          <param name="max">3.15</param>
-        </command_interface>
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
@@ -98,14 +86,8 @@
         <state_interface name="effort"/>
       </joint>
       <joint name="${tf_prefix}elbow_joint">
-        <command_interface name="position">
-          <param name="min">{-pi}</param>
-          <param name="max">{pi}</param>
-        </command_interface>
-        <command_interface name="velocity">
-          <param name="min">-3.15</param>
-          <param name="max">3.15</param>
-        </command_interface>
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['elbow_joint']}</param>
@@ -114,14 +96,8 @@
         <state_interface name="effort"/>
       </joint>
       <joint name="${tf_prefix}wrist_1_joint">
-        <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
-        </command_interface>
-        <command_interface name="velocity">
-          <param name="min">-3.2</param>
-          <param name="max">3.2</param>
-        </command_interface>
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
@@ -130,14 +106,8 @@
         <state_interface name="effort"/>
       </joint>
       <joint name="${tf_prefix}wrist_2_joint">
-        <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
-        </command_interface>
-        <command_interface name="velocity">
-          <param name="min">-3.2</param>
-          <param name="max">3.2</param>
-        </command_interface>
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
@@ -146,14 +116,8 @@
         <state_interface name="effort"/>
       </joint>
       <joint name="${tf_prefix}wrist_3_joint">
-        <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
-        </command_interface>
-        <command_interface name="velocity">
-          <param name="min">-3.2</param>
-          <param name="max">3.2</param>
-        </command_interface>
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['wrist_3_joint']}</param>


### PR DESCRIPTION
They have never been parsed before Jazzy and in Jazzy the URDF limits will be used unless a more strict limit is configured inside the ros2_control tags.

This is a manual backport of #166 

@Mergifyio backport humble