### PR TITLE
Added dynamics tag when using mock_components/GenericSystem

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -35,6 +35,7 @@
           <plugin>mock_components/GenericSystem</plugin>
           <param name="fake_sensor_commands">${fake_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
+          <param name="calculate_dynamics">true</param>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware or sim_gazebo or sim_ignition}">
           <plugin>ur_robot_driver/URPositionHardwareInterface</plugin>


### PR DESCRIPTION
The title is self-explanatory.
I had to create a custom ROS controller that outputs velocities. Without this additional line, no velocity-based controller will ever move the robot in Rviz when using the mock hardware interface.

Niccolò