### PR TITLE
Revert "Add passthrough command interfaces for joints (#204)"

### DIFF
--- a/urdf/inc/ur_joint_control.xacro
+++ b/urdf/inc/ur_joint_control.xacro
@@ -8,9 +8,6 @@
     <joint name="${tf_prefix}shoulder_pan_joint">
       <command_interface name="position"/>
       <command_interface name="velocity"/>
-      <command_interface name="passthrough_position"/>
-      <command_interface name="passthrough_velocity"/>
-      <command_interface name="passthrough_acceleration"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
@@ -25,9 +22,6 @@
     <joint name="${tf_prefix}shoulder_lift_joint">
       <command_interface name="position"/>
       <command_interface name="velocity"/>
-      <command_interface name="passthrough_position"/>
-      <command_interface name="passthrough_velocity"/>
-      <command_interface name="passthrough_acceleration"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
@@ -42,9 +36,6 @@
     <joint name="${tf_prefix}elbow_joint">
       <command_interface name="position"/>
       <command_interface name="velocity"/>
-      <command_interface name="passthrough_position"/>
-      <command_interface name="passthrough_velocity"/>
-      <command_interface name="passthrough_acceleration"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['elbow_joint']}</param>
@@ -59,9 +50,6 @@
     <joint name="${tf_prefix}wrist_1_joint">
       <command_interface name="position"/>
       <command_interface name="velocity"/>
-      <command_interface name="passthrough_position"/>
-      <command_interface name="passthrough_velocity"/>
-      <command_interface name="passthrough_acceleration"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
@@ -76,9 +64,6 @@
     <joint name="${tf_prefix}wrist_2_joint">
       <command_interface name="position"/>
       <command_interface name="velocity"/>
-      <command_interface name="passthrough_position"/>
-      <command_interface name="passthrough_velocity"/>
-      <command_interface name="passthrough_acceleration"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
@@ -93,9 +78,6 @@
     <joint name="${tf_prefix}wrist_3_joint">
       <command_interface name="position"/>
       <command_interface name="velocity"/>
-      <command_interface name="passthrough_position"/>
-      <command_interface name="passthrough_velocity"/>
-      <command_interface name="passthrough_acceleration"/>
       <state_interface name="position">
         <!-- initial position for the mock system and simulation -->
         <param name="initial_value">${initial_positions['wrist_3_joint']}</param>


### PR DESCRIPTION
This reverts commit 6b1a77624da84461ceaf9ff32ab5a1ff62705e61.

I had a bad feeling about this and hence also only released it to rolling. Thinking about this a bit, it occurred to me that -- since we want to send other motion types in the future -- it doesn't make sense necessarily to add this to the joints.