### PR TITLE
Add missing state interfaces for get_version service

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -281,6 +281,12 @@
           <state_interface name="initialized"/>
         </gpio>
 
+        <gpio name="${tf_prefix}get_robot_software_version">
+          <state_interface name="get_version_major"/>
+          <state_interface name="get_version_minor"/>
+          <state_interface name="get_version_build"/>
+          <state_interface name="get_version_bugfix"/>
+        </gpio>
       </xacro:unless>
 
     </ros2_control>


### PR DESCRIPTION
This is required for https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1128