### PR TITLE
Add analog_output_domain_cmd command interface

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -167,6 +167,7 @@
 
           <command_interface name="standard_analog_output_cmd_0"/>
           <command_interface name="standard_analog_output_cmd_1"/>
+          <command_interface name="analog_output_domain_cmd"/>
 
           <command_interface name="tool_voltage_cmd"/>
 


### PR DESCRIPTION
This will be required for https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1131