### PR TITLE
Added ground plane to URDF for simulators

### DIFF
--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -57,6 +57,30 @@
    <!-- create link fixed to the "world" -->
    <link name="world" />
 
+   <link name="ground_plane">
+     <visual>
+       <origin rpy="0 0 0" xyz="0 0 0"/>
+       <geometry>
+         <box size="5 5 0"/>
+       </geometry>
+       <material name="ground_white">
+         <color rgba="1 1 1 0.5"/>
+       </material>
+     </visual>
+     <collision>
+       <origin rpy="0 0 0" xyz="0 0 0"/>
+       <geometry>
+         <box size="5 5 0"/>
+       </geometry>
+     </collision>
+   </link>
+
+   <joint name="ground_plane_joint" type="fixed">
+     <origin xyz="0 0 -0.01" rpy="0 0 0"/>
+     <parent link="world"/>
+     <child link="ground_plane"/>
+   </joint>
+
    <!-- arm -->
    <xacro:ur_robot
      name="$(arg name)"

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -53,33 +53,37 @@
 
    <!-- convert to property to use substitution in function -->
    <xacro:property name="initial_positions_file" default="$(arg initial_positions_file)"/>
+   <xacro:property name="is_sim_gazebo" value="$(arg sim_gazebo)"/>
+   <xacro:property name="is_sim_ignition" value="$(arg sim_ignition)"/>
 
    <!-- create link fixed to the "world" -->
    <link name="world" />
 
-   <link name="ground_plane">
-     <visual>
-       <origin rpy="0 0 0" xyz="0 0 0"/>
-       <geometry>
-         <box size="5 5 0"/>
-       </geometry>
-       <material name="ground_white">
-         <color rgba="1 1 1 0.5"/>
-       </material>
-     </visual>
-     <collision>
-       <origin rpy="0 0 0" xyz="0 0 0"/>
-       <geometry>
-         <box size="5 5 0"/>
-       </geometry>
-     </collision>
-   </link>
+   <xacro:if value="${is_sim_gazebo or is_sim_ignition}">
+     <link name="ground_plane">
+       <visual>
+         <origin rpy="0 0 0" xyz="0 0 0"/>
+         <geometry>
+           <box size="5 5 0"/>
+         </geometry>
+         <material name="ground_white">
+           <color rgba="1 1 1 0.5"/>
+         </material>
+       </visual>
+       <collision>
+         <origin rpy="0 0 0" xyz="0 0 0"/>
+         <geometry>
+           <box size="5 5 0"/>
+         </geometry>
+       </collision>
+     </link>
 
-   <joint name="ground_plane_joint" type="fixed">
-     <origin xyz="0 0 -0.01" rpy="0 0 0"/>
-     <parent link="world"/>
-     <child link="ground_plane"/>
-   </joint>
+     <joint name="ground_plane_joint" type="fixed">
+       <origin xyz="0 0 -0.01" rpy="0 0 0"/>
+       <parent link="world"/>
+       <child link="ground_plane"/>
+     </joint>
+   </xacro:if>
 
    <!-- arm -->
    <xacro:ur_robot


### PR DESCRIPTION
This PR adds a ground plane in the URDF to match the one present in gazebo, avoiding unfeasible planning solutions. It solves #217.