### PR TITLE
Assure the description is loaded as string

### DIFF
--- a/launch/view_ur.launch.py
+++ b/launch/view_ur.launch.py
@@ -33,6 +33,7 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
@@ -128,7 +129,9 @@ def generate_launch_description():
             tf_prefix,
         ]
     )
-    robot_description = {"robot_description": robot_description_content}
+    robot_description = {
+        "robot_description": ParameterValue(value=robot_description_content, value_type=str)
+    }
 
     joint_state_publisher_node = Node(
         package="joint_state_publisher_gui",


### PR DESCRIPTION
If this isn't explicitly specified, the description string might be interpreted as a yaml content, which leads to problems, obviously.

Fixes #227 