### PR TITLE
Release/3.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+3.0.0 (2024-12-11)
+------------------
 * Remove Iron workflows and from README (`#230 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/230>`_)
 * Assure the description is loaded as string (`#229 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/229>`_)
 * Contributors: Felix Exner

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ur_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove Iron workflows and from README (`#230 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/230>`_)
+* Assure the description is loaded as string (`#229 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/229>`_)
+* Contributors: Felix Exner
+
 2.4.5 (2024-10-14)
 ------------------
 * Revert "Add passthrough command interfaces for joints (`#204 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/204>`_)" (`#214 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/214>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_description</name>
-  <version>2.4.5</version>
+  <version>3.0.0</version>
   <description>
     URDF description for Universal Robots
   </description>


### PR DESCRIPTION
As usual, please approve only or rebase-merge. I'll push the tag and bloom-release later.

The major bump does not really reflect the changes made in this release cycle but the commitment to do proper semantic versioning from now on. Humble will live on 2.x.y., Jazzy on 3.x.y and rolling will branch out for 4.x.y once making backwards-incompatible changes to jazzy.