### PR TITLE
Change fake_sensor_commands->mock_sensor_commands

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="ur_ros2_control" params="
     name
-    use_fake_hardware:=false fake_sensor_commands:=false
+    use_fake_hardware:=false mock_sensor_commands:=false
     sim_gazebo:=false
     sim_ignition:=false
     headless_mode:=false
@@ -33,7 +33,7 @@
         </xacro:if>
         <xacro:if value="${use_fake_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
-          <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+          <param name="mock_sensor_commands">${mock_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
           <param name="calculate_dynamics">true</param>
         </xacro:if>

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -43,7 +43,7 @@
 
      <!-- Simulation parameters -->
    <xacro:arg name="use_fake_hardware" default="false" />
-   <xacro:arg name="fake_sensor_commands" default="false" />
+   <xacro:arg name="mock_sensor_commands" default="false" />
    <xacro:arg name="sim_gazebo" default="false" />
    <xacro:arg name="sim_ignition" default="false" />
    <xacro:arg name="simulation_controllers" default="" />
@@ -99,7 +99,7 @@
      safety_pos_margin="$(arg safety_pos_margin)"
      safety_k_position="$(arg safety_k_position)"
      use_fake_hardware="$(arg use_fake_hardware)"
-     fake_sensor_commands="$(arg fake_sensor_commands)"
+     mock_sensor_commands="$(arg mock_sensor_commands)"
      sim_gazebo="$(arg sim_gazebo)"
      sim_ignition="$(arg sim_ignition)"
      headless_mode="$(arg headless_mode)"

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -68,7 +68,7 @@
     safety_pos_margin:=0.15
     safety_k_position:=20
     use_fake_hardware:=false
-    fake_sensor_commands:=false
+    mock_sensor_commands:=false
     sim_gazebo:=false
     sim_ignition:=false
     headless_mode:=false
@@ -113,7 +113,7 @@
         name="${name}"
         use_fake_hardware="${use_fake_hardware}"
         initial_positions="${initial_positions}"
-        fake_sensor_commands="${fake_sensor_commands}"
+        mock_sensor_commands="${mock_sensor_commands}"
         headless_mode="${headless_mode}"
         sim_gazebo="${sim_gazebo}"
         sim_ignition="${sim_ignition}"


### PR DESCRIPTION
Hello,

we found this in the ros2_control xacro breaks on newer humble snapshots in MoveIt Pro as the parameter name got changed. Has this been UR's experience as well? I think this fix only applies to humble, but let me know if we need to put this in a different upstream.

Thanks,
Shaur 