### PR TITLE
[BREAKING] Remove rotation between base_link and kinematic chain

### DIFF
--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -76,8 +76,7 @@
       force_abs_paths="${force_abs_paths}"/>
 
     <!-- links -  main serial chain -->
-    <link name="${tf_prefix}base_link"/>
-    <link name="${tf_prefix}base_link_inertia">
+    <link name="${tf_prefix}base_link">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
         <geometry>
@@ -268,18 +267,8 @@
     </joint>
 
     <!-- joints - main serial chain -->
-    <joint name="${tf_prefix}base_link-base_link_inertia" type="fixed">
-      <parent link="${tf_prefix}base_link" />
-      <child link="${tf_prefix}base_link_inertia" />
-      <!-- 'base_link' is REP-103 aligned (so X+ forward), while the internal
-           frames of the robot/controller have X+ pointing backwards.
-           Use the joint between 'base_link' and 'base_link_inertia' (a dummy
-           link/frame) to introduce the necessary rotation over Z (of pi rad).
-      -->
-      <origin xyz="0 0 0" rpy="0 0 ${pi}" />
-    </joint>
     <joint name="${tf_prefix}shoulder_pan_joint" type="revolute">
-      <parent link="${tf_prefix}base_link_inertia" />
+      <parent link="${tf_prefix}base_link" />
       <child link="${tf_prefix}shoulder_link" />
       <origin xyz="${shoulder_x} ${shoulder_y} ${shoulder_z}" rpy="${shoulder_roll} ${shoulder_pitch} ${shoulder_yaw}" />
       <axis xyz="0 0 1" />
@@ -374,7 +363,7 @@
            to correctly align 'base' with the 'Base' coordinate system of
            the UR controller.
       -->
-      <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <parent link="${tf_prefix}base_link"/>
       <child link="${tf_prefix}base"/>
     </joint>


### PR DESCRIPTION
## Introduction

The robot's kinematic chain was rotated around the base_link, mainly because of historic reasons. For this, an additional link called `base_link_inertia` was introduced rotated 180 deg around base_link just as `base`.

This commit removes this additional link which effectively rotates the whole robot relative to `base_link` around 180 deg. This also makes `base_link` go in line with `base` which should help reducing a lot of confusion.

For example, users have been doing lookups from `base_link` to `tool0` and  were wondering why there are changed axes compared to what the the teach pendant shows.

I don't really see a reason for having this apart from backwards compatibility, which is why I would like to propose this change.

## Suggested changes

**Before this:**
<img src="https://github.com/user-attachments/assets/60fdd5dd-6e57-419f-8454-1a7659edef45" width="40%"/> <img src="https://github.com/user-attachments/assets/8ca990d0-d39e-43c8-9af4-7cbad3c185a4" width="40%"/>

**After this**
<img src="https://github.com/user-attachments/assets/bf3f8e5c-e44c-45ac-be4e-a2ec32934f9b" width="40%" /> <img src="https://github.com/user-attachments/assets/244c0d90-f9e4-4b91-911d-a611d4218d54" width="40%" />

The images show the same perspective, meaning the pose of `base_link` is the same in both versions.

Obviously, this would be breaking existing setups which is why this hasn't been done all the years. With Kilted just around the corner with a couple of minor breaks ahead (see #280) this could be a good opportunity to change this.

**Note: This would mean that every user would have to change their URDF integrations, as the robot will be rotated 180 degrees. We could potentially add an opt-in argument to the xacro to perform this change to allow users to gradually migrate over the runtime of Kilted (Could be potentially backported to Jazzy and humble) and then make the hard cut with ROS L. Either way we should be very explicit communicating this (upcoming) change.**

## ToDo
- [ ] Implement feature
- [ ] Potentially add opt-in argument
- [ ] Add migration notes entry with a clear guide what has to be changed
- [ ] Test with driver
- [ ] Test with Gazebo simulation

@gavanderhoorn I hope you don't mind me tagging you here since you were involved in originally creating the `base_link`->`base` structure. I would love having your opinion on this.

---

*Edit:* Looking back at the comment removed in this PR originally introduced in https://github.com/ros-industrial/universal_robot/commit/e47d3f688897cded793b0d07ffd18e26ffb679a2 it could be argued (and probably was the reason originally) that **forward** is the direction where the arm is pointing to for an all-zeros configuration.