### PR TITLE
Add an initial value for the major_version state interface

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -361,7 +361,9 @@
       </gpio>
 
         <gpio name="${tf_prefix}get_robot_software_version">
-          <state_interface name="get_version_major"/>
+          <state_interface name="get_version_major">
+            <param name="initial_value">1</param>
+          </state_interface>
           <state_interface name="get_version_minor"/>
           <state_interface name="get_version_build"/>
           <state_interface name="get_version_bugfix"/>


### PR DESCRIPTION
This can be used in mock hardware tests. We've done the same for Rolling in https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1226