### PR TITLE
Do not add effort command interface for GZ sim

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -69,7 +69,9 @@
       <joint name="${tf_prefix}shoulder_pan_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="$(arg sim_ignition)">
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
@@ -80,7 +82,9 @@
       <joint name="${tf_prefix}shoulder_lift_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="$(arg sim_ignition)">
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
@@ -91,7 +95,9 @@
       <joint name="${tf_prefix}elbow_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="$(arg sim_ignition)">
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['elbow_joint']}</param>
@@ -102,7 +108,9 @@
       <joint name="${tf_prefix}wrist_1_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="$(arg sim_ignition)">
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
@@ -113,7 +121,9 @@
       <joint name="${tf_prefix}wrist_2_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="$(arg sim_ignition)">
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
@@ -124,7 +134,9 @@
       <joint name="${tf_prefix}wrist_3_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <command_interface name="effort"/>
+        <xacro:unless value="$(arg sim_ignition)">
+          <command_interface name="effort"/>
+        </xacro:unless>
         <state_interface name="position">
           <!-- initial position for the FakeSystem and simulation -->
           <param name="initial_value">${initial_positions['wrist_3_joint']}</param>


### PR DESCRIPTION
gz_ros2_control seems to not cope fine with having the effort command interface. As this is only an issue with Humble (Only tested with GZ Sim Fortress), let's deactivate it in that case.

I don't quite know why that happens. It could potentially be an issue with GZ Fortress or somewhere in the gz_ros2_control humble version. This does not happen with Jazzy and above.