### PR TITLE
Replace argument replacements with properties

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -69,7 +69,7 @@
       <joint name="${tf_prefix}shoulder_pan_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <xacro:unless value="$(arg sim_ignition)">
+        <xacro:unless value="${sim_ignition}">
           <command_interface name="effort"/>
         </xacro:unless>
         <state_interface name="position">
@@ -82,7 +82,7 @@
       <joint name="${tf_prefix}shoulder_lift_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <xacro:unless value="$(arg sim_ignition)">
+        <xacro:unless value="${sim_ignition}">
           <command_interface name="effort"/>
         </xacro:unless>
         <state_interface name="position">
@@ -95,7 +95,7 @@
       <joint name="${tf_prefix}elbow_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <xacro:unless value="$(arg sim_ignition)">
+        <xacro:unless value="${sim_ignition}">
           <command_interface name="effort"/>
         </xacro:unless>
         <state_interface name="position">
@@ -108,7 +108,7 @@
       <joint name="${tf_prefix}wrist_1_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <xacro:unless value="$(arg sim_ignition)">
+        <xacro:unless value="${sim_ignition}">
           <command_interface name="effort"/>
         </xacro:unless>
         <state_interface name="position">
@@ -121,7 +121,7 @@
       <joint name="${tf_prefix}wrist_2_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <xacro:unless value="$(arg sim_ignition)">
+        <xacro:unless value="${sim_ignition}">
           <command_interface name="effort"/>
         </xacro:unless>
         <state_interface name="position">
@@ -134,7 +134,7 @@
       <joint name="${tf_prefix}wrist_3_joint">
         <command_interface name="position"/>
         <command_interface name="velocity"/>
-        <xacro:unless value="$(arg sim_ignition)">
+        <xacro:unless value="${sim_ignition}">
           <command_interface name="effort"/>
         </xacro:unless>
         <state_interface name="position">


### PR DESCRIPTION
Otherwise that won't work when including this from another xacro where those arguments aren't available.

Consider this simplified URDF:

```xml
<?xml version="1.0"?>
<robot xmlns:xacro="http://wiki.ros.org/xacro" name="ur">
   <!-- import main macro -->
   <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>

   <xacro:arg name="ur_type" default="ur5e"/>

   <xacro:arg name="tf_prefix" default="" />
   <xacro:arg name="joint_limit_params" default="$(find ur_description)/config/$(arg ur_type)/joint_limits.yaml"/>
   <xacro:arg name="kinematics_params" default="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"/>
   <xacro:arg name="physical_params" default="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"/>
   <xacro:arg name="visual_params" default="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"/>

   <xacro:arg name="initial_positions_file" default="$(find ur_description)/config/initial_positions.yaml"/>

   <xacro:property name="initial_positions_file" default="$(arg initial_positions_file)"/>

   <link name="world" />

   <xacro:ur_robot
     name="ur5e"
     tf_prefix=""
     parent="world"
     joint_limits_parameters_file="$(arg joint_limit_params)"
     kinematics_parameters_file="$(arg kinematics_params)"
     physical_parameters_file="$(arg physical_params)"
     visual_parameters_file="$(arg visual_params)"
     sim_gazebo="false"
     sim_ignition="true"
     >
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ur_robot>
</robot>
```

The `sim_ignition` parameter is passed to the `ur_robot_macro`, as one might expect it. However, with the `humble` branch version this will fail with

```console
$ xacro test.urdf
Undefined substitution argument sim_ignition
when instantiating macro: ur_ros2_control (/home/robot/checkout/ur_humble/colcon_ws/install/ur_description/share/ur_description/urdf/ur.ros2_control.xacro)
instantiated from: ur_robot (/home/robot/checkout/ur_humble/colcon_ws/install/ur_description/share/ur_description/urdf/ur_macro.xacro)
in file: test.urdf
```

Inside the macro was read from an argument, that is defined outside of the macro file. This only coincidently works as long as we use it in a xacro structure where this argument is defined.

This PR reads the value not from the global **argument** but from the **macro parameter** which gets stored into a property.

The test URDF from above works fine with the changes from this branch.