### PR TITLE
Use XML launchfile instead of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All other content is licensed under the BSD-3-Clause license
 To visualize the robot install this repository to you workspace and execute the following:
 
 ``` bash
-ros2 launch ur_description view_ur.launch.py ur_type:=ur5e
+ros2 launch ur_description view_ur.launch.xml ur_type:=ur5e
 ```
 
 To test other descriptions change the `ur_type` argument.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,7 +60,7 @@ Arguments that have to be passed to the main ``ur.urdf.xacro`` file are:
  - physical_params - Filename to the ``physical_parameters.yaml`` file
  - visual_params - Filename to the ``visual_params.yaml`` file
 
-The launchfile ``launch/view_ur.launch.py`` abstracts these four parameters to one ``ur_type`` argument
+The launchfile ``launch/view_ur.launch.xml`` abstracts these four parameters to one ``ur_type`` argument
 which will basically replace the ``urXX`` part of the paths as shown in the picture above.
 
 ros2_control integration

--- a/doc/migration/lyrical.rst
+++ b/doc/migration/lyrical.rst
@@ -1,0 +1,11 @@
+:github_url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/rolling/doc/migration/kilted.rst
+
+ur_description
+^^^^^^^^^^^^^^
+
+XML launch files
+~~~~~~~~~~~~~~~~
+
+In Lyrical, we introduced Python launch files to this package. The Python launch files will coexist
+for now, but might get removed in a future release. All launch file arguments are the same for both
+XML and Python launch files, so you can easily switch between them.

--- a/doc/migration_notes.rst
+++ b/doc/migration_notes.rst
@@ -10,3 +10,8 @@ Jazzy -> Kilted
 ^^^^^^^^^^^^^^^
 .. include:: migration/kilted.rst
     :start-line: 4
+
+Kilted -> Lyrical
+^^^^^^^^^^^^^^^^^
+.. include:: migration/lyrical.rst
+    :start-line: 4

--- a/launch/view_ur.launch.py
+++ b/launch/view_ur.launch.py
@@ -29,147 +29,38 @@
 # Author: Denis Stogl
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch_ros.parameter_descriptions import ParameterValue
+
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import FrontendLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
 
 def generate_launch_description():
-    declared_arguments = []
-    # UR specific arguments
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "ur_type",
-            description="Type/series of used UR robot.",
-            choices=[
-                "ur3",
-                "ur5",
-                "ur10",
-                "ur3e",
-                "ur5e",
-                "ur7e",
-                "ur10e",
-                "ur12e",
-                "ur16e",
-                "ur8long",
-                "ur15",
-                "ur18",
-                "ur20",
-                "ur30",
-            ],
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "safety_limits",
-            default_value="true",
-            description="Enables the safety limits controller if true.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "safety_pos_margin",
-            default_value="0.15",
-            description="The margin to lower and upper limits in the safety controller.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "safety_k_position",
-            default_value="20",
-            description="k-position factor in the safety controller.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "description_file",
-            default_value=PathJoinSubstitution(
-                [FindPackageShare("ur_description"), "urdf", "ur.urdf.xacro"]
-            ),
-            description="URDF/XACRO description file (absolute path) with the robot.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "rviz_config_file",
-            default_value=PathJoinSubstitution(
-                [FindPackageShare("ur_description"), "rviz", "view_robot.rviz"]
-            ),
-            description="RViz config file (absolute path) to use when launching rviz.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "tf_prefix",
-            default_value='""',
-            description="Prefix of the joint names, useful for "
-            "multi-robot setup. If changed than also joint names in the controllers' configuration "
-            "have to be updated.",
-        )
-    )
 
-    # Initialize Arguments
-    ur_type = LaunchConfiguration("ur_type")
-    safety_limits = LaunchConfiguration("safety_limits")
-    safety_pos_margin = LaunchConfiguration("safety_pos_margin")
-    safety_k_position = LaunchConfiguration("safety_k_position")
-    description_file = LaunchConfiguration("description_file")
-    tf_prefix = LaunchConfiguration("tf_prefix")
-    rviz_config_file = LaunchConfiguration("rviz_config_file")
-
-    robot_description_content = Command(
+    return LaunchDescription(
         [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
-            " ",
-            description_file,
-            " ",
-            "safety_limits:=",
-            safety_limits,
-            " ",
-            "safety_pos_margin:=",
-            safety_pos_margin,
-            " ",
-            "safety_k_position:=",
-            safety_k_position,
-            " ",
-            "name:=",
-            "ur",
-            " ",
-            "ur_type:=",
-            ur_type,
-            " ",
-            "tf_prefix:=",
-            tf_prefix,
+            IncludeLaunchDescription(
+                FrontendLaunchDescriptionSource(
+                    [
+                        PathJoinSubstitution(
+                            [
+                                FindPackageShare("ur_description"),
+                                "launch",
+                                "view_ur.launch.xml",
+                            ]
+                        )
+                    ]
+                ),
+                launch_arguments={
+                    "ur_type": LaunchConfiguration("ur_type"),
+                    "rviz_config_file": LaunchConfiguration("rviz_config_file"),
+                    "description_file": LaunchConfiguration("description_file"),
+                    "tf_prefix": LaunchConfiguration("tf_prefix"),
+                    "safety_limits": LaunchConfiguration("safety_limits"),
+                    "safety_pos_margin": LaunchConfiguration("safety_pos_margin"),
+                    "safety_k_position": LaunchConfiguration("safety_k_position"),
+                }.items(),
+            )
         ]
     )
-    robot_description = {
-        "robot_description": ParameterValue(value=robot_description_content, value_type=str)
-    }
-
-    joint_state_publisher_node = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-    )
-    robot_state_publisher_node = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        output="both",
-        parameters=[robot_description],
-    )
-    rviz_node = Node(
-        package="rviz2",
-        executable="rviz2",
-        name="rviz2",
-        output="log",
-        arguments=["-d", rviz_config_file],
-    )
-
-    nodes_to_start = [
-        joint_state_publisher_node,
-        robot_state_publisher_node,
-        rviz_node,
-    ]
-
-    return LaunchDescription(declared_arguments + nodes_to_start)

--- a/launch/view_ur.launch.py
+++ b/launch/view_ur.launch.py
@@ -54,12 +54,6 @@ def generate_launch_description():
                 ),
                 launch_arguments={
                     "ur_type": LaunchConfiguration("ur_type"),
-                    "rviz_config_file": LaunchConfiguration("rviz_config_file"),
-                    "description_file": LaunchConfiguration("description_file"),
-                    "tf_prefix": LaunchConfiguration("tf_prefix"),
-                    "safety_limits": LaunchConfiguration("safety_limits"),
-                    "safety_pos_margin": LaunchConfiguration("safety_pos_margin"),
-                    "safety_k_position": LaunchConfiguration("safety_k_position"),
                 }.items(),
             )
         ]

--- a/launch/view_ur.launch.xml
+++ b/launch/view_ur.launch.xml
@@ -38,6 +38,6 @@
   <node pkg="joint_state_publisher_gui" exec="joint_state_publisher_gui" />
   <node pkg="rviz2" exec="rviz2" args="-d $(var rviz_config_file)" />
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
-    <param name="robot_description" value="$(command '$(find-exec xacro) $(var description_file) ur_type:=$(var ur_type) name:=ur safety_limits:=$(var safety_limits) safety_pos_margin:=$(var safety_pos_margin) safety_k_position:=$(var safety_k_position)')"/>
+    <param name="robot_description" value="$(command '$(find-exec xacro) $(var description_file) ur_type:=$(var ur_type) name:=ur safety_limits:=$(var safety_limits) safety_pos_margin:=$(var safety_pos_margin) safety_k_position:=$(var safety_k_position) tf_prefix:=$(var tf_prefix)')"/>
   </node>
 </launch>

--- a/launch/view_ur.launch.xml
+++ b/launch/view_ur.launch.xml
@@ -25,10 +25,19 @@
   <arg name="tf_prefix"
        default=""
        description="Prefix of the joint names, useful for multi-robot setup. If changed than also joint names in the controllers' configuration have to be updated." />
+  <arg name="safety_limits"
+       default="true"
+       description="Enables the safety limits controller if true." />
+  <arg name="safety_pos_margin"
+       default="0.15"
+       description="The margin to lower and upper limits in the safety controller." />
+  <arg name="safety_k_position"
+        default="20"
+        description="The gain for the position controller in the safety controller." />
 
   <node pkg="joint_state_publisher_gui" exec="joint_state_publisher_gui" />
   <node pkg="rviz2" exec="rviz2" args="-d $(var rviz_config_file)" />
   <node pkg="robot_state_publisher" exec="robot_state_publisher">
-    <param name="robot_description" value="$(command '$(find-exec xacro) $(var description_file) ur_type:=$(var ur_type) name:=ur')"/>
+    <param name="robot_description" value="$(command '$(find-exec xacro) $(var description_file) ur_type:=$(var ur_type) name:=ur safety_limits:=$(var safety_limits) safety_pos_margin:=$(var safety_pos_margin) safety_k_position:=$(var safety_k_position)')"/>
   </node>
 </launch>

--- a/launch/view_ur.launch.xml
+++ b/launch/view_ur.launch.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="rviz_config_file"
+       default="$(find-pkg-share ur_description)/rviz/view_robot.rviz"
+       description="RViz config file (absolute path) to use when launching rviz." />
+  <arg name="description_file"
+       default="$(find-pkg-share ur_description)/urdf/ur.urdf.xacro"
+       description="URDF/XACRO description file (absolute path) with the robot." />
+  <arg name="ur_type" description="Type/series of used UR robot.">
+     <choice value="ur3"/>
+     <choice value="ur5"/>
+     <choice value="ur10"/>
+     <choice value="ur3e"/>
+     <choice value="ur5e"/>
+     <choice value="ur7e"/>
+     <choice value="ur10e"/>
+     <choice value="ur12e"/>
+     <choice value="ur16e"/>
+     <choice value="ur8long"/>
+     <choice value="ur15"/>
+     <choice value="ur18"/>
+     <choice value="ur20"/>
+     <choice value="ur30"/>
+  </arg>
+  <arg name="tf_prefix"
+       default=""
+       description="Prefix of the joint names, useful for multi-robot setup. If changed than also joint names in the controllers' configuration have to be updated." />
+
+  <node pkg="joint_state_publisher_gui" exec="joint_state_publisher_gui" />
+  <node pkg="rviz2" exec="rviz2" args="-d $(var rviz_config_file)" />
+  <node pkg="robot_state_publisher" exec="robot_state_publisher">
+    <param name="robot_description" value="$(command '$(find-exec xacro) $(var description_file) ur_type:=$(var ur_type) name:=ur')"/>
+  </node>
+</launch>


### PR DESCRIPTION
I've had this lying around locally for quite a while now. Since XML launchfiles are mature enough to be used by now, I would like to use them throughout our ecosystem a bit more. It reduces the complexity to read launchfiles significantly.

I kept the python-based launchfiles for backwards compatibility, though, in the long run I would vote for deleting them, maybe for ROS M.