### PR TITLE
Correct offsets of wrist3 meshes

### DIFF
--- a/config/ur10/visual_parameters.yaml
+++ b/config/ur10/visual_parameters.yaml
@@ -114,7 +114,7 @@ mesh_files:
         path: meshes/ur10/collision/wrist3.stl
     mesh_offset:
       x: 0.0
-      y: 0.0
+      y: 0.001
       z: -0.0922
       roll: !degrees 90
       pitch: 0.0

--- a/config/ur10e/visual_parameters.yaml
+++ b/config/ur10e/visual_parameters.yaml
@@ -115,7 +115,7 @@ mesh_files:
         path: meshes/ur10e/collision/wrist3.stl
     mesh_offset:
       x: 0.0
-      y: 0.0
+      y: -0.0005
       z: -0.1168
       roll: !degrees 90
       pitch: 0.0

--- a/config/ur12e/visual_parameters.yaml
+++ b/config/ur12e/visual_parameters.yaml
@@ -115,7 +115,7 @@ mesh_files:
         path: meshes/ur10e/collision/wrist3.stl
     mesh_offset:
       x: 0.0
-      y: 0.0
+      y: -0.0005
       z: -0.1168
       roll: !degrees 90
       pitch: 0.0

--- a/config/ur16e/visual_parameters.yaml
+++ b/config/ur16e/visual_parameters.yaml
@@ -116,7 +116,7 @@ mesh_files:
         path: meshes/ur10e/collision/wrist3.stl
     mesh_offset:
       x: 0.0
-      y: 0.0
+      y: -0.0005
       z: -0.1168
       roll: !degrees 90
       pitch: 0.0

--- a/config/ur3/visual_parameters.yaml
+++ b/config/ur3/visual_parameters.yaml
@@ -115,7 +115,7 @@ mesh_files:
         path: meshes/ur3/collision/wrist3.stl
     mesh_offset:
       x: 0.0
-      y: -0.00255
+      y: -0.002
       z: -0.082
       roll: !degrees 90
       pitch: 0.0

--- a/config/ur5e/visual_parameters.yaml
+++ b/config/ur5e/visual_parameters.yaml
@@ -115,7 +115,7 @@ mesh_files:
         path: meshes/ur5e/collision/wrist3.stl
     mesh_offset:
       x: 0.0
-      y: 0.0
+      y: -0.0005
       z: -0.0989
       roll: !degrees 90
       pitch: 0.0

--- a/config/ur7e/visual_parameters.yaml
+++ b/config/ur7e/visual_parameters.yaml
@@ -115,7 +115,7 @@ mesh_files:
         path: meshes/ur5e/collision/wrist3.stl
     mesh_offset:
       x: 0.0
-      y: 0.0
+      y: -0.0005
       z: -0.0989
       roll: !degrees 90
       pitch: 0.0


### PR DESCRIPTION
Some of the older meshes had a wrong offset. We correct this in this PR by adding an additional offset in the URDF. This is more a workaround, but it avoids re-creating the meshes.

Fixes #139

I checked all models and fixed the ones where wrist3 wasn't rotating cleanly:

- UR10 – corrected by 1mm 
- UR10e – corrected by 0.5mm 
- UR12e – corrected by 0.5mm 
- UR16e – corrected by 0.5mm 
- UR3 – corrected by 0.55mm 
- UR3e – ok 
- UR5 – ok 
- UR5e – corrected by 0.5mm 
- UR7e – corrected by 0.5mm 
- UR15 – ok  
- UR18 – ok  
- UR20 – ok  
- UR8Long – ok  