### PR TITLE
Add ros2_control param for model verification

### DIFF
--- a/urdf/ur.ros2_control.xacro
+++ b/urdf/ur.ros2_control.xacro
@@ -21,6 +21,8 @@
     trajectory_port:=50003
     non_blocking_read:=true
     keep_alive_count:=2
+    ur_type:=unknown
+    verify_robot_model:=false
     ">
 
     <ros2_control name="${name}" type="system">
@@ -43,6 +45,7 @@
           <param name="script_filename">${script_filename}</param>
           <param name="output_recipe_filename">${output_recipe_filename}</param>
           <param name="input_recipe_filename">${input_recipe_filename}</param>
+          <param name="ur_type">${ur_type}</param>
           <param name="headless_mode">${headless_mode}</param>
           <param name="reverse_port">${reverse_port}</param>
           <param name="script_sender_port">${script_sender_port}</param>
@@ -64,6 +67,7 @@
           <param name="tool_device_name">${tool_device_name}</param>
           <param name="tool_tcp_port">${tool_tcp_port}</param>
           <param name="keep_alive_count">${keep_alive_count}</param>
+          <param name="verify_robot_model">${verify_robot_model}</param>
         </xacro:unless>
       </hardware>
       <joint name="${tf_prefix}shoulder_pan_joint">

--- a/urdf/ur.urdf.xacro
+++ b/urdf/ur.urdf.xacro
@@ -30,6 +30,7 @@
    <xacro:arg name="reverse_port" default="50001"/>
    <xacro:arg name="script_sender_port" default="50002"/>
    <xacro:arg name="trajectory_port" default="50003"/>
+   <xacro:arg name="verify_robot_model" default="false" />
    <!--   tool communication related parameters-->
    <xacro:arg name="use_tool_communication" default="false" />
    <xacro:arg name="tool_voltage" default="0" />
@@ -122,6 +123,8 @@
      reverse_port="$(arg reverse_port)"
      script_sender_port="$(arg script_sender_port)"
      trajectory_port="$(arg trajectory_port)"
+     ur_type="$(arg ur_type)"
+     verify_robot_model="$(arg verify_robot_model)"
      >
      <origin xyz="0 0 0" rpy="0 0 0" />          <!-- position robot in the world -->
    </xacro:ur_robot>

--- a/urdf/ur_macro.xacro
+++ b/urdf/ur_macro.xacro
@@ -62,6 +62,7 @@
     kinematics_parameters_file
     physical_parameters_file
     visual_parameters_file
+    ur_type:=unknown
     generate_ros2_control_tag:=true
     transmission_hw_interface:=hardware_interface/PositionJointInterface
     safety_limits:=false
@@ -92,7 +93,8 @@
     script_command_port:=50004
     trajectory_port:=50003
     non_blocking_read:=true
-    keep_alive_count:=2"
+    keep_alive_count:=2
+    verify_robot_model:=false"
 
     >
 
@@ -139,6 +141,8 @@
         trajectory_port="${trajectory_port}"
         non_blocking_read="${non_blocking_read}"
         keep_alive_count="${keep_alive_count}"
+        ur_type="${ur_type}"
+        verify_robot_model="${verify_robot_model}"
         />
     </xacro:if>
 


### PR DESCRIPTION
Defaulting to disabled and an unknown ur_type, as adding ur_type as a required parameter would effectively be a breaking change.

This is required for https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1790