### PR TITLE
Increase minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.25.1)
 project(ur_description)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Increase minimum version to 3.25.1 which is the version on Debian Bookworm, since this branch is also targeting ROS Kilted at the moment.

See https://docs.ros.org/en/rolling/Releases/Release-Kilted-Kaiju.html#supported-platforms for the minimum version.